### PR TITLE
Fix small typo in MassAssignmentSecurity documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ MassAssignment methods to honor any declared mass assignment permission
 blacklists or whitelists including support for mass assignment roles.
 
     class Person
-      include ActiveAttr::MassAssignment
+      include ActiveAttr::MassAssignmentSecurity
       attr_accessor :first_name, :last_name
       attr_protected :last_name
     end


### PR DESCRIPTION
Fixed a small typo in the MassAssignmentSecurity documentation; the include statement was for `MassAssignment`, not `MassAssignmentSecurity`
