### PR TITLE
clobber and attribute!

### DIFF
--- a/spec/functional/active_attr/attributes_spec.rb
+++ b/spec/functional/active_attr/attributes_spec.rb
@@ -201,6 +201,22 @@ module ActiveAttr
         it "defining an attribute that conflicts with a less properly implemented method_missing callback raises DangerousAttributeError" do
           expect { model_class.attribute(:my_less_proper_missing_method) }.to raise_error DangerousAttributeError
         end
+
+        context "and specifying :clobber" do
+          %w(write_attribute attribute_method_matchers puts class instance_eval my_proper_missing_method my_less_proper_missing_method).map(&:to_sym).each do |method_to_clobber|
+            it "defining #{method_to_clobber} does not raise" do
+              expect { model_class.attribute(method_to_clobber, :clobber => true) }.not_to raise_error
+            end
+          end
+        end
+
+        context "using the attribute! method" do
+          %w(write_attribute attribute_method_matchers puts class instance_eval my_proper_missing_method my_less_proper_missing_method).map(&:to_sym).each do |method_to_clobber|
+            it "defining #{method_to_clobber} does not raise" do
+              expect { model_class.attribute!(method_to_clobber) }.not_to raise_error
+            end
+          end
+        end
       end
 
       let :dangerous_model_class do

--- a/spec/functional/active_attr/query_attributes_spec.rb
+++ b/spec/functional/active_attr/query_attributes_spec.rb
@@ -16,6 +16,20 @@ module ActiveAttr
         it "defining an attribute that conflicts with Object raises DangerousAttributeError" do
           expect { model_class.attribute(:nil) }.to raise_error DangerousAttributeError
         end
+
+        context "and specifying :clobber" do
+          it "defining an attribute that conflicts with ActiveModel::AttributeMethods raises DangerousAttributeError" do
+            expect { model_class.attribute(:attribute_method, :clobber => true) }.not_to raise_error
+          end
+
+          it "defining an attribute that conflicts with Kernel raises DangerousAttributeError" do
+            expect { model_class.attribute(:block_given, :clobber => true) }.not_to raise_error
+          end
+
+          it "defining an attribute that conflicts with Object raises DangerousAttributeError" do
+            expect { model_class.attribute(:nil, :clobber => true) }.not_to raise_error
+          end
+        end
       end
 
       context "on a model class" do

--- a/spec/unit/active_attr/attributes_spec.rb
+++ b/spec/unit/active_attr/attributes_spec.rb
@@ -99,6 +99,13 @@ module ActiveAttr
       end
     end
 
+    describe ".attribute!" do
+      it "calls .attribute with :clobber" do
+        model_class.should_receive(:attribute).with(:foo, {:clobber => true, :ho => :boy})
+        model_class.attribute!(:foo, :ho => :boy)
+      end
+    end
+
     describe ".attributes" do
       it { model_class.should respond_to(:attributes) }
 


### PR DESCRIPTION
add :clobber option to attribute, and equivalent attribute! method to disregard name clashes when defining attributes
