### PR TITLE
Use ActiveModel::ForbiddenAttributesProtection

### DIFF
--- a/lib/active_attr/mass_assignment_security.rb
+++ b/lib/active_attr/mass_assignment_security.rb
@@ -18,7 +18,7 @@ module ActiveAttr
   module MassAssignmentSecurity
     extend ActiveSupport::Concern
     include MassAssignment
-    include ActiveModel::MassAssignmentSecurity
+    include ActiveModel::ForbiddenAttributesProtection
 
     # Mass update a model's attributes, honoring attribute permissions
     #


### PR DESCRIPTION
ActiveModel::MassAssignmentSecurity is deprecated in Rails HEAD (4.0). Got `uninitialized constant ActiveModel::MassAssignmentSecurity` when running ActiveAttr agains Rails HEAD. This pull request fixes this.
