### PR TITLE
Read/write attribute directly from @attributes to match ActiveModel

### DIFF
--- a/lib/active_attr/attributes.rb
+++ b/lib/active_attr/attributes.rb
@@ -57,7 +57,7 @@ module ActiveAttr
     #
     # @since 0.2.0
     def attributes
-      attributes_map { |name| send name }
+      attributes_map { |name| attribute name }
     end
 
     # Returns the class name plus its attributes

--- a/spec/unit/active_attr/attributes_spec.rb
+++ b/spec/unit/active_attr/attributes_spec.rb
@@ -201,8 +201,8 @@ module ActiveAttr
       end
 
       context "when a getter is overridden" do
-        it "uses the overridden implementation" do
-          model.attributes.should include("last_name" => last_name)
+        it "uses the original value" do
+          model.attributes.should include("last_name" => nil)
         end
       end
     end
@@ -211,7 +211,7 @@ module ActiveAttr
       before { model.first_name = "Ben" }
 
       it "includes the class name and all attribute values in alphabetical order by attribute name" do
-        model.inspect.should == %{#<Foo amount: nil, first_name: "Ben", last_name: "#{last_name}">}
+        model.inspect.should == %{#<Foo amount: nil, first_name: "Ben", last_name: nil>}
       end
 
       it "doesn't format the inspection string for attributes if the model does not have any" do
@@ -219,8 +219,8 @@ module ActiveAttr
       end
 
       context "when a getter is overridden" do
-        it "uses the overridden implementation" do
-          model.inspect.should include %{last_name: "#{last_name}"}
+        it "uses the original value" do
+          model.inspect.should include %{last_name: nil}
         end
       end
     end


### PR DESCRIPTION
Resolves #113

This allows overridden getters/setters to be written like ActiveModel getters/setters and call `read_attribute` and `write_attribute` to get the raw value from the attributes hash. This previous behavior was unexpected to users bringing existing code from ActiveModel.

The other benefit of this change is that `ActiveModel::Dirty` can be included and will actually behave properly since it overrides `write_attribute`, expecting it to be called when a setter is called.

While I feel strongly that this should be fixed, it's a very significant change and should probably accompany a decent version bump. Thoughts?
