### PR TITLE
Make typecasting more consistent with how typecasting works in ActiveRec...

### DIFF
--- a/lib/active_attr/typecasting/big_decimal_typecaster.rb
+++ b/lib/active_attr/typecasting/big_decimal_typecaster.rb
@@ -25,6 +25,8 @@ module ActiveAttr
       #
       # @since 0.5.0
       def call(value)
+        return nil if value.nil? || value == ''
+        value = value.gsub(',', '') if value.is_a?(String)
         if value.is_a? BigDecimal
           value
         elsif value.is_a? Rational

--- a/lib/active_attr/typecasting/date_time_typecaster.rb
+++ b/lib/active_attr/typecasting/date_time_typecaster.rb
@@ -25,6 +25,7 @@ module ActiveAttr
       # @since 0.5.0
       def call(value)
         value.to_datetime if value.respond_to? :to_datetime
+      rescue NoMethodError, ArgumentError
       end
     end
   end

--- a/lib/active_attr/typecasting/float_typecaster.rb
+++ b/lib/active_attr/typecasting/float_typecaster.rb
@@ -20,7 +20,7 @@ module ActiveAttr
       #
       # @since 0.5.0
       def call(value)
-        value.to_f if value.respond_to? :to_f
+        value.to_f if value.respond_to?(:to_f) && !value.nil? && value != ''
       end
     end
   end

--- a/lib/active_attr/typecasting/integer_typecaster.rb
+++ b/lib/active_attr/typecasting/integer_typecaster.rb
@@ -21,7 +21,7 @@ module ActiveAttr
       #
       # @since 0.5.0
       def call(value)
-        value.to_i if value.respond_to? :to_i
+        value.to_i if value.respond_to?(:to_i) && !value.nil? && value != ''
       rescue FloatDomainError
       end
     end

--- a/spec/unit/active_attr/typecasting/big_decimal_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/big_decimal_typecaster_spec.rb
@@ -12,16 +12,24 @@ module ActiveAttr
           typecaster.call(value).should equal value
         end
 
-        it "casts nil to a zero BigDecimal" do
-          typecaster.call(nil).should eql BigDecimal.new("0.0")
+        it "casts nil to nil" do
+          typecaster.call(nil).should be_nil
         end
 
         it "casts a numeric String to a BigDecimal" do
           typecaster.call("2").should eql BigDecimal.new("2.0")
         end
 
+        it "correctly casts a numeric String with thousand separator to BigDecimal" do
+          typecaster.call("1,000.00").should eql BigDecimal.new("1000")
+        end
+
         it "casts a alpha String to a zero BigDecimal" do
           typecaster.call("bob").should eql BigDecimal.new("0.0")
+        end
+
+        it "casts an empty String to a BigDecimal" do
+          typecaster.call('').should be_nil
         end
 
         it "casts a Rational to a BigDecimal" do

--- a/spec/unit/active_attr/typecasting/date_time_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/date_time_typecaster_spec.rb
@@ -16,6 +16,10 @@ module ActiveAttr
           typecaster.call(nil).should equal nil
         end
 
+        it "returns nil for an invalid String" do
+          typecaster.call("x").should equal nil
+        end
+
         it "casts a Date to a DateTime at the beginning of the day with no offset" do
           result = typecaster.call(Date.new(2012, 1, 1))
           result.should eql DateTime.new(2012, 1, 1)

--- a/spec/unit/active_attr/typecasting/float_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/float_typecaster_spec.rb
@@ -12,8 +12,12 @@ module ActiveAttr
           typecaster.call(value).should equal value
         end
 
-        it "casts nil to 0.0" do
-          typecaster.call(nil).should eql 0.0
+        it "returns nil for nil" do
+          typecaster.call(nil).should be_nil
+        end
+
+        it "returns nil for empty String" do
+          typecaster.call('').should be_nil
         end
 
         it "returns the float version of a String" do

--- a/spec/unit/active_attr/typecasting/integer_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/integer_typecaster_spec.rb
@@ -12,12 +12,16 @@ module ActiveAttr
           typecaster.call(value).should equal value
         end
 
-        it "casts nil to 0" do
-          typecaster.call(nil).should eql 0
+        it "returns nil for nil" do
+          typecaster.call(nil).should be_nil
         end
 
         it "returns the integer version of a String" do
           typecaster.call("2").should eql 2
+        end
+
+        it "returns nil for empty String" do
+          typecaster.call('').should be_nil
         end
 
         it "returns nil for an object that does not respond to #to_i" do


### PR DESCRIPTION
...ord. Empty strings for numeric fields should be casted to nil, nil should be casted to nil. Invalid DateTime values should be handled the same way as invalid Date values are handled, i.e. they should be casted to nil.
