### PR TITLE
object allocation: attribute_names and attributes_map

### DIFF
--- a/lib/active_attr/attributes.rb
+++ b/lib/active_attr/attributes.rb
@@ -150,7 +150,11 @@ module ActiveAttr
     #
     # @since 0.7.0
     def attributes_map
-      Hash[ self.class.attribute_names.map { |name| [name, yield(name)] } ]
+      {}.tap do |attributes_hash|
+        self.class.attribute_names.each do |k|
+          attributes_hash[k] = yield(k)
+        end
+      end
     end
 
     module ClassMethods

--- a/lib/active_attr/attributes.rb
+++ b/lib/active_attr/attributes.rb
@@ -203,6 +203,7 @@ module ActiveAttr
           remove_instance_variable("@attribute_methods_generated") if instance_variable_defined?("@attribute_methods_generated")
           define_attribute_methods([attribute_definition.name]) unless attribute_names.include? attribute_name
           attributes[attribute_name] = attribute_definition
+          @attribute_names = attributes.keys
         end
       end
 
@@ -215,7 +216,7 @@ module ActiveAttr
       #
       # @since 0.5.0
       def attribute_names
-        attributes.keys
+        @attribute_names ||= attributes.keys
       end
 
       # Returns a Hash of AttributeDefinition instances


### PR DESCRIPTION
Two things:

`hash.keys` creates a new array each time it's called but that list doesn't change that often, so this hangs onto it.

By making `attributes_map` a little uglier, we save one more array at the beginning and then another for each pairing of attribute and value! The overall object allocation improves performance, especially when a model has a large number of properties.
