### PR TITLE
Convert specs to RSpec 3.3.2 syntax with Transpec

### DIFF
--- a/spec/functional/active_attr/attribute_defaults_spec.rb
+++ b/spec/functional/active_attr/attribute_defaults_spec.rb
@@ -20,25 +20,25 @@ module ActiveAttr
       before { model_class.attribute :first_name, :default => "John" }
 
       it "the attribute getter returns the string by default" do
-        model.first_name.should == "John"
+        expect(model.first_name).to eq("John")
       end
 
       it "#attributes includes the default attributes" do
-        model.attributes["first_name"].should == "John"
+        expect(model.attributes["first_name"]).to eq("John")
       end
 
       it "#read_attribute returns the string by default" do
-        model.read_attribute("first_name").should == "John"
+        expect(model.read_attribute("first_name")).to eq("John")
       end
 
       it "assigning nil sets nil as the attribute value" do
         model.first_name = nil
-        model.first_name.should be_nil
+        expect(model.first_name).to be_nil
       end
 
       it "mutating the default value does not mutate the attribute definition" do
         model_class.new.first_name.upcase!
-        model_class.new.first_name.should == "John"
+        expect(model_class.new.first_name).to eq("John")
       end
     end
 
@@ -46,7 +46,7 @@ module ActiveAttr
       before { model_class.attribute :admin, :default => false }
 
       it "the attribute getter returns false by default" do
-        model.admin.should == false
+        expect(model.admin).to eq(false)
       end
     end
 
@@ -54,7 +54,7 @@ module ActiveAttr
       before { model_class.attribute :remember_me, :default => true }
 
       it "the attribute getter returns true by default" do
-        model.remember_me.should == true
+        expect(model.remember_me).to eq(true)
       end
     end
 
@@ -62,7 +62,7 @@ module ActiveAttr
       before { model_class.attribute :roles, :default => [] }
 
       it "the attribute getter returns an empty array by default" do
-        model.roles.should == []
+        expect(model.roles).to eq([])
       end
     end
 
@@ -70,15 +70,15 @@ module ActiveAttr
       before { model_class.attribute :created_at, :default => lambda { Time.now } }
 
       it "the attribute getter returns a Time instance" do
-        model.created_at.should be_a_kind_of Time
+        expect(model.created_at).to be_a_kind_of Time
       end
 
       it "the attribute default is only evaulated once per instance" do
-        model.created_at.should == model.created_at
+        expect(model.created_at).to eq(model.created_at)
       end
 
       it "the attribute default is different per instance" do
-        model_class.new.created_at.should_not equal model_class.new.created_at
+        expect(model_class.new.created_at).not_to equal model_class.new.created_at
       end
     end
 
@@ -86,7 +86,7 @@ module ActiveAttr
       before { model_class.attribute :id, :default => lambda { object_id } }
 
       it "the attribute getter returns the default based on the instance" do
-        model.id.should == model.object_id
+        expect(model.id).to eq(model.object_id)
       end
     end
 
@@ -103,23 +103,23 @@ module ActiveAttr
       end
 
       it "applies the default attributes" do
-        model_class.new.age_limit.should == 21
+        expect(model_class.new.age_limit).to eq(21)
       end
 
       it "mass assignment at initialization overrides the defaults" do
-        model_class.new(:age_limit => 18).age_limit.should == 18
+        expect(model_class.new(:age_limit => 18).age_limit).to eq(18)
       end
 
       it "mass assignment at initialization can override the default with a nil value" do
-        model_class.new(:age_limit => nil).age_limit.should be_nil
+        expect(model_class.new(:age_limit => nil).age_limit).to be_nil
       end
 
       it "dynamic defaults have access to other attribute methods" do
-        model_class.new.end_date.should be_nil
+        expect(model_class.new.end_date).to be_nil
       end
 
       it "dynamic defaults have access to attributes mass assigned at initialization" do
-        model_class.new(:start_date => Date.today).end_date.should == Date.today
+        expect(model_class.new(:start_date => Date.today).end_date).to eq(Date.today)
       end
     end
 
@@ -135,11 +135,11 @@ module ActiveAttr
       end
 
       it "typecasts a default value literal" do
-        model_class.new.age.should == 21
+        expect(model_class.new.age).to eq(21)
       end
 
       it "typecasts a dynamic default" do
-        model_class.new.start_date.should == Date.today.to_s
+        expect(model_class.new.start_date).to eq(Date.today.to_s)
       end
     end
   end

--- a/spec/functional/active_attr/attributes_spec.rb
+++ b/spec/functional/active_attr/attributes_spec.rb
@@ -26,7 +26,7 @@ module ActiveAttr
       subject(:model) { model_class.new }
 
       it "correctly defines methods for the attributes instead of relying on method_missing" do
-        model.id.should be_nil
+        expect(model.id).to be_nil
       end
     end
 
@@ -53,15 +53,15 @@ module ActiveAttr
         subject { child_class.new }
 
         it "create a reader on the child" do
-          should respond_to :parent
+          is_expected.to respond_to :parent
         end
 
         it "create a writer on the child" do
-          should respond_to :parent=
+          is_expected.to respond_to :parent=
         end
 
         it "add attribute definitions to the child" do
-          child_class.attribute_names.should include "parent"
+          expect(child_class.attribute_names).to include "parent"
         end
       end
 
@@ -69,25 +69,25 @@ module ActiveAttr
         subject { parent_class.new }
 
         it "don't create a reader on the parent" do
-          should_not respond_to :child
+          is_expected.not_to respond_to :child
         end
 
         it "don't create a writer on the parent" do
-          should_not respond_to :child=
+          is_expected.not_to respond_to :child=
         end
 
         it "don't add attribute definitions to the parent" do
-          parent_class.attribute_names.should_not include "child"
+          expect(parent_class.attribute_names).not_to include "child"
         end
       end
 
       context "attributes redefined on the child" do
         it "redefines the child attribute" do
-          child_class.attributes[:redefined].should == AttributeDefinition.new(:redefined, :type => String)
+          expect(child_class.attributes[:redefined]).to eq(AttributeDefinition.new(:redefined, :type => String))
         end
 
         it "does not redefine the parent attribute" do
-          parent_class.attributes[:redefined].should == AttributeDefinition.new(:redefined, :type => Symbol)
+          expect(parent_class.attributes[:redefined]).to eq(AttributeDefinition.new(:redefined, :type => Symbol))
         end
       end
     end
@@ -119,12 +119,12 @@ module ActiveAttr
 
       shared_examples "serialization method" do
         it "includes assigned attributes" do
-          should include("first_name" => first_name)
+          is_expected.to include("first_name" => first_name)
         end
 
         it "includes unassigned, defined attributes" do
-          serialized_model.keys.should include("last_name")
-          serialized_model["last_name"].should be_nil
+          expect(serialized_model.keys).to include("last_name")
+          expect(serialized_model["last_name"]).to be_nil
         end
       end
 
@@ -177,19 +177,19 @@ module ActiveAttr
       end
 
       it "builds an instance of the model class" do
-        should be_a_kind_of Person
+        is_expected.to be_a_kind_of Person
       end
 
       it "sets the attributes" do
-        model.first_name.should eq "Chris"
-        model.last_name.should == "Griego"
+        expect(model.first_name).to eq "Chris"
+        expect(model.last_name).to eq("Griego")
       end
     end
 
     context "defining dangerous attributes" do
       shared_examples "a dangerous attribute" do
         it ".dangerous_attribute? is truthy" do
-          model_class.dangerous_attribute?(attribute_name).should be_truthy
+          expect(model_class.dangerous_attribute?(attribute_name)).to be_truthy
         end
 
         it ".attribute raises DangerousAttributeError" do
@@ -203,7 +203,7 @@ module ActiveAttr
 
       shared_examples "a whitelisted attribute" do
         it ".dangerous_attribute? is falsey" do
-          model_class.dangerous_attribute?(attribute_name).should be_falsey
+          expect(model_class.dangerous_attribute?(attribute_name)).to be_falsey
         end
 
         it ".attribute does not raise" do
@@ -219,7 +219,7 @@ module ActiveAttr
           model = model_class.new
           value = double
           model.send "#{attribute_name}=", value
-          model.send(attribute_name).should equal value
+          expect(model.send(attribute_name)).to equal value
         end
       end
 

--- a/spec/functional/active_attr/chainable_initialization_spec.rb
+++ b/spec/functional/active_attr/chainable_initialization_spec.rb
@@ -9,7 +9,7 @@ module ActiveAttr
     shared_examples "chained initialization" do
       describe "#initialize" do
         it { expect { model }.not_to raise_error }
-        it { model.initialized?.should == true }
+        it { expect(model.initialized?).to eq(true) }
       end
     end
 

--- a/spec/functional/active_attr/mass_assignment_spec.rb
+++ b/spec/functional/active_attr/mass_assignment_spec.rb
@@ -19,24 +19,24 @@ module ActiveAttr
 
         it "ignores assigning an attribute protected by role-based security", :active_model_version => ">= 3.1.0" do
           person = mass_assign_attributes(:age => 21)
-          person.age.should be_nil
+          expect(person.age).to be_nil
         end
 
         it "ignores assigning a protected attribute" do
           person = mass_assign_attributes(:first_name => "Chris")
-          person.age.should be_nil
+          expect(person.age).to be_nil
         end
       end
 
       shared_examples "secure mass assignment method with options", :secure_mass_assignment_method_with_options => true do
         it "supports role-based mass assignment security", :active_model_version => ">= 3.1.0" do
           person = mass_assign_attributes_with_options({ :age => 21 }, :as => :admin)
-          person.age.should == 21
+          expect(person.age).to eq(21)
         end
 
         it "skips security if passed the :without_protection option" do
           person = mass_assign_attributes_with_options({ :age => 21 }, :without_protection => true)
-          person.age.should == 21
+          expect(person.age).to eq(21)
         end
       end
 
@@ -103,17 +103,17 @@ module ActiveAttr
 
         it "sets a permitted parameter" do
           person = mass_assign_attributes(ActionController::Parameters.new(:age => 21).permit(:age))
-          person.age.should == 21
+          expect(person.age).to eq(21)
         end
 
         it "does not set forbidden parameters" do
           person = mass_assign_attributes(ActionController::Parameters.new(:age => 21).permit(:first_name))
-          person.age.should be_nil
+          expect(person.age).to be_nil
         end
 
         it "continues to set normal attributes" do
           person = mass_assign_attributes(:age => 21)
-          person.age.should == 21
+          expect(person.age).to eq(21)
         end
       end
 

--- a/spec/functional/active_attr/matchers/have_attribute_matcher_spec.rb
+++ b/spec/functional/active_attr/matchers/have_attribute_matcher_spec.rb
@@ -30,13 +30,13 @@ module ActiveAttr
         end
 
         describe "#matches?" do
-          it { matcher.matches?(model_class).should == false }
+          it { expect(matcher.matches?(model_class)).to eq(false) }
         end
 
         describe "#failure_message" do
           before { matcher.matches?(model_class) }
 
-          it { matcher.failure_message.should == %{expected #{model_class.name} to include ActiveAttr::Attributes} }
+          it { expect(matcher.failure_message).to eq(%{expected #{model_class.name} to include ActiveAttr::Attributes}) }
         end
       end
 
@@ -52,13 +52,13 @@ module ActiveAttr
         end
 
         describe "#matches?" do
-          it { matcher.matches?(model_class).should == false }
+          it { expect(matcher.matches?(model_class)).to eq(false) }
         end
 
         describe "#failure_message" do
           before { matcher.matches?(model_class) }
 
-          it { matcher.failure_message.should == %{expected #{model_class.name} to include ActiveAttr::AttributeDefaults} }
+          it { expect(matcher.failure_message).to eq(%{expected #{model_class.name} to include ActiveAttr::AttributeDefaults}) }
         end
       end
 
@@ -74,13 +74,13 @@ module ActiveAttr
         end
 
         describe "#matches?" do
-          it { matcher.matches?(model_class).should == false }
+          it { expect(matcher.matches?(model_class)).to eq(false) }
         end
 
         describe "#failure_message" do
           before { matcher.matches?(model_class) }
 
-          it { matcher.failure_message.should == %{expected #{model_class.name} to include ActiveAttr::TypecastedAttributes} }
+          it { expect(matcher.failure_message).to eq(%{expected #{model_class.name} to include ActiveAttr::TypecastedAttributes}) }
         end
       end
 
@@ -93,7 +93,7 @@ module ActiveAttr
           before { model_class.attribute :first_name }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == true }
+            it { expect(matcher.matches?(model_class)).to eq(true) }
           end
 
           [:negative_failure_message, :failure_message_when_negated].each do |method|
@@ -101,7 +101,7 @@ module ActiveAttr
               before { matcher.matches?(model_class) }
 
               it do
-                matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
+                expect(matcher.send(method)).to eq <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :first_name
                            got: attribute :first_name
                 MESSAGE
@@ -112,13 +112,13 @@ module ActiveAttr
 
         context "a class without the attribute" do
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
-            it { matcher.failure_message.should == %{expected Person to have attribute named first_name} }
+            it { expect(matcher.failure_message).to eq(%{expected Person to have attribute named first_name}) }
           end
         end
       end
@@ -133,14 +133,14 @@ module ActiveAttr
           before { model_class.attribute :first_name }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
             it do
-              matcher.failure_message.should == <<-MESSAGE.strip_heredoc.chomp
+              expect(matcher.failure_message).to eq <<-MESSAGE.strip_heredoc.chomp
                 expected: attribute :first_name, :default => "John"
                      got: attribute :first_name
               MESSAGE
@@ -152,14 +152,14 @@ module ActiveAttr
           before { model_class.attribute :first_name, :default => "Doe" }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
             it do
-              matcher.failure_message.should == <<-MESSAGE.strip_heredoc.chomp
+              expect(matcher.failure_message).to eq <<-MESSAGE.strip_heredoc.chomp
                 expected: attribute :first_name, :default => "John"
                      got: attribute :first_name, :default => "Doe"
               MESSAGE
@@ -171,7 +171,7 @@ module ActiveAttr
           before { model_class.attribute :first_name, :default => "John" }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == true }
+            it { expect(matcher.matches?(model_class)).to eq(true) }
           end
 
           [:negative_failure_message, :failure_message_when_negated].each do |method|
@@ -179,7 +179,7 @@ module ActiveAttr
               before { matcher.matches?(model_class) }
 
               it do
-                matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
+                expect(matcher.send(method)).to eq <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :first_name, :default => "John"
                            got: attribute :first_name, :default => "John"
                 MESSAGE
@@ -199,14 +199,14 @@ module ActiveAttr
           before { model_class.attribute :admin }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
             it do
-              matcher.failure_message.should == <<-MESSAGE.strip_heredoc.chomp
+              expect(matcher.failure_message).to eq <<-MESSAGE.strip_heredoc.chomp
                 expected: attribute :admin, :default => false
                      got: attribute :admin
               MESSAGE
@@ -218,14 +218,14 @@ module ActiveAttr
           before { model_class.attribute :admin, :default => nil }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
             it do
-              matcher.failure_message.should == <<-MESSAGE.strip_heredoc.chomp
+              expect(matcher.failure_message).to eq <<-MESSAGE.strip_heredoc.chomp
                 expected: attribute :admin, :default => false
                      got: attribute :admin, :default => nil
               MESSAGE
@@ -237,7 +237,7 @@ module ActiveAttr
           before { model_class.attribute :admin, :default => false }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == true }
+            it { expect(matcher.matches?(model_class)).to eq(true) }
           end
 
           [:negative_failure_message, :failure_message_when_negated].each do |method|
@@ -245,7 +245,7 @@ module ActiveAttr
               before { matcher.matches?(model_class) }
 
               it do
-                matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
+                expect(matcher.send(method)).to eq <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :admin, :default => false
                            got: attribute :admin, :default => false
                 MESSAGE
@@ -265,7 +265,7 @@ module ActiveAttr
           before { model_class.attribute :first_name }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == true }
+            it { expect(matcher.matches?(model_class)).to eq(true) }
           end
 
           [:negative_failure_message, :failure_message_when_negated].each do |method|
@@ -273,7 +273,7 @@ module ActiveAttr
               before { matcher.matches?(model_class) }
 
               it do
-                matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
+                expect(matcher.send(method)).to eq <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :first_name, :default => nil
                            got: attribute :first_name
                 MESSAGE
@@ -286,14 +286,14 @@ module ActiveAttr
           before { model_class.attribute :first_name, :default => false }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
             it do
-              matcher.failure_message.should == <<-MESSAGE.strip_heredoc.chomp
+              expect(matcher.failure_message).to eq <<-MESSAGE.strip_heredoc.chomp
                 expected: attribute :first_name, :default => nil
                      got: attribute :first_name, :default => false
               MESSAGE
@@ -305,7 +305,7 @@ module ActiveAttr
           before { model_class.attribute :first_name, :default => nil }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == true }
+            it { expect(matcher.matches?(model_class)).to eq(true) }
           end
 
           [:negative_failure_message, :failure_message_when_negated].each do |method|
@@ -313,7 +313,7 @@ module ActiveAttr
               before { matcher.matches?(model_class) }
 
               it do
-                matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
+                expect(matcher.send(method)).to eq <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :first_name, :default => nil
                            got: attribute :first_name, :default => nil
                 MESSAGE
@@ -333,14 +333,14 @@ module ActiveAttr
           before { model_class.attribute :first_name }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
             it do
-              matcher.failure_message.should == <<-MESSAGE.strip_heredoc.chomp
+              expect(matcher.failure_message).to eq <<-MESSAGE.strip_heredoc.chomp
                 expected: attribute :first_name, :type => String
                      got: attribute :first_name
               MESSAGE
@@ -352,14 +352,14 @@ module ActiveAttr
           before { model_class.attribute :first_name, :type => Symbol }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
             it do
-              matcher.failure_message.should == <<-MESSAGE.strip_heredoc.chomp
+              expect(matcher.failure_message).to eq <<-MESSAGE.strip_heredoc.chomp
                 expected: attribute :first_name, :type => String
                      got: attribute :first_name, :type => Symbol
               MESSAGE
@@ -371,7 +371,7 @@ module ActiveAttr
           before { model_class.attribute :first_name, :type => String }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == true }
+            it { expect(matcher.matches?(model_class)).to eq(true) }
           end
 
           [:negative_failure_message, :failure_message_when_negated].each do |method|
@@ -379,7 +379,7 @@ module ActiveAttr
               before { matcher.matches?(model_class) }
 
               it do
-                matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
+                expect(matcher.send(method)).to eq <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :first_name, :type => String
                            got: attribute :first_name, :type => String
                 MESSAGE
@@ -399,7 +399,7 @@ module ActiveAttr
           before { model_class.attribute :first_name }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == true }
+            it { expect(matcher.matches?(model_class)).to eq(true) }
           end
 
           [:negative_failure_message, :failure_message_when_negated].each do |method|
@@ -407,7 +407,7 @@ module ActiveAttr
               before { matcher.matches?(model_class) }
 
               it do
-                matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
+                expect(matcher.send(method)).to eq <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :first_name, :type => Object
                            got: attribute :first_name
                 MESSAGE
@@ -420,14 +420,14 @@ module ActiveAttr
           before { model_class.attribute :first_name, :type => String }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == false }
+            it { expect(matcher.matches?(model_class)).to eq(false) }
           end
 
           describe "#failure_message" do
             before { matcher.matches?(model_class) }
 
             it do
-              matcher.failure_message.should == <<-MESSAGE.strip_heredoc.chomp
+              expect(matcher.failure_message).to eq <<-MESSAGE.strip_heredoc.chomp
                 expected: attribute :first_name, :type => Object
                      got: attribute :first_name, :type => String
               MESSAGE
@@ -439,7 +439,7 @@ module ActiveAttr
           before { model_class.attribute :first_name, :type => Object }
 
           describe "#matches?" do
-            it { matcher.matches?(model_class).should == true }
+            it { expect(matcher.matches?(model_class)).to eq(true) }
           end
 
           [:negative_failure_message, :failure_message_when_negated].each do |method|
@@ -447,7 +447,7 @@ module ActiveAttr
               before { matcher.matches?(model_class) }
 
               it do
-                matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
+                expect(matcher.send(method)).to eq <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :first_name, :type => Object
                            got: attribute :first_name, :type => Object
                 MESSAGE

--- a/spec/functional/active_attr/model_spec.rb
+++ b/spec/functional/active_attr/model_spec.rb
@@ -31,45 +31,45 @@ module ActiveAttr
 
     it "reads and writes attributes" do
       model.first_name = "Chris"
-      model.first_name.should eq "Chris"
-      model.attributes["first_name"].should == "Chris"
+      expect(model.first_name).to eq "Chris"
+      expect(model.attributes["first_name"]).to eq("Chris")
     end
 
     it "can query attributes" do
-      model.first_name?.should eq false
+      expect(model.first_name?).to eq false
       model.first_name = "Chris"
-      model.first_name?.should == true
+      expect(model.first_name?).to eq(true)
     end
 
     it "initializes with a block that can use attributes" do
-      model_class.new do |person|
+      expect(model_class.new do |person|
         person.write_attribute :first_name, "Chris"
-      end.read_attribute(:first_name).should == "Chris"
+      end.read_attribute(:first_name)).to eq("Chris")
     end
 
     it "processes mass assignment before yielding to an initialization block" do
       model_class.new(:first_name => "Chris") do |person|
-        person.first_name.should == "Chris"
+        expect(person.first_name).to eq("Chris")
       end
     end
 
     it "has a logger" do
       logger = double("logger")
-      model_class.logger?.should eq false
-      model.logger?.should eq false
+      expect(model_class.logger?).to eq false
+      expect(model.logger?).to eq false
 
       model_class.logger = logger
 
-      model_class.logger?.should eq true
-      model_class.logger.should eq logger
-      model.logger?.should eq true
-      model.logger.should == logger
+      expect(model_class.logger?).to eq true
+      expect(model_class.logger).to eq logger
+      expect(model.logger?).to eq true
+      expect(model.logger).to eq(logger)
     end
 
     it "supports mass assignment with security" do
       person = model_class.new(:first_name => "Chris", :last_name => "Griego")
-      person.first_name.should eq "Chris"
-      person.last_name.should be_nil
+      expect(person.first_name).to eq "Chris"
+      expect(person.last_name).to be_nil
     end
 
     it "does not use strict mass assignment" do
@@ -78,23 +78,23 @@ module ActiveAttr
 
     it "serializes to/from JSON" do
       model.first_name = "Chris"
-      model_class.new.from_json(model.to_json).first_name.should == "Chris"
+      expect(model_class.new.from_json(model.to_json).first_name).to eq("Chris")
     end
 
     it "serializes to/from XML" do
       model.first_name = "Chris"
       model.last_name = "Griego"
       model.age = 21
-      model_class.new.from_xml(model.to_xml).first_name.should == "Chris"
+      expect(model_class.new.from_xml(model.to_xml).first_name).to eq("Chris")
     end
 
     it "supports attribute name translation" do
-      model_class.human_attribute_name(:first_name).should == "First name"
+      expect(model_class.human_attribute_name(:first_name)).to eq("First name")
     end
 
     it "typecasts attributes" do
       model.age = "29"
-      model.age.should eql 29
+      expect(model.age).to eql 29
     end
 
     context "attribute defaults" do
@@ -110,21 +110,21 @@ module ActiveAttr
       end
 
       it "are applied" do
-        model.age_limit.should == 21
+        expect(model.age_limit).to eq(21)
       end
 
       it "are overridden by mass assigned attributes" do
-        model_class.new(:age_limit => 18).age_limit.should == 18
+        expect(model_class.new(:age_limit => 18).age_limit).to eq(18)
       end
 
       it "can access mass assigned attributes" do
-        model_class.new(:start_date => Date.today).end_date.should == Date.today
+        expect(model_class.new(:start_date => Date.today).end_date).to eq(Date.today)
       end
 
       it "can access attributes assigned in the initialization block" do
-        model_class.new do |event|
+        expect(model_class.new do |event|
           event.start_date = Date.today
-        end.end_date.should == Date.today
+        end.end_date).to eq(Date.today)
       end
     end
   end

--- a/spec/functional/active_attr/serialization_spec.rb
+++ b/spec/functional/active_attr/serialization_spec.rb
@@ -20,12 +20,12 @@ module ActiveAttr
 
     it "serializes to/from JSON" do
       model.first_name = "Chris"
-      model_class.new.from_json(model.to_json).first_name.should == "Chris"
+      expect(model_class.new.from_json(model.to_json).first_name).to eq("Chris")
     end
 
     it "serializes to/from XML" do
       model.first_name = "Chris"
-      model_class.new.from_xml(model.to_xml).first_name.should == "Chris"
+      expect(model_class.new.from_xml(model.to_xml).first_name).to eq("Chris")
     end
   end
 end

--- a/spec/functional/active_attr/typecasted_attributes_spec.rb
+++ b/spec/functional/active_attr/typecasted_attributes_spec.rb
@@ -31,7 +31,7 @@ module ActiveAttr
     context "when assigning nil" do
       it "a typeless attribute returns nil" do
         model.typeless = nil
-        model.typeless.should be_nil
+        expect(model.typeless).to be_nil
       end
 
       it "an attribute with no known typecaster raises" do
@@ -41,47 +41,47 @@ module ActiveAttr
 
       it "an attribute with an inline typecaster returns nil" do
         model.age = nil
-        model.age.should be_nil
+        expect(model.age).to be_nil
       end
 
       it "an Object attribute returns nil" do
         model.object = nil
-        model.object.should be_nil
+        expect(model.object).to be_nil
       end
 
       it "a BigDecimal attribute returns nil" do
         model.big_decimal = nil
-        model.big_decimal.should be_nil
+        expect(model.big_decimal).to be_nil
       end
 
       it "a Boolean attribute returns nil" do
         model.boolean = nil
-        model.boolean.should be_nil
+        expect(model.boolean).to be_nil
       end
 
       it "a Date attribute returns nil" do
         model.date = nil
-        model.date.should be_nil
+        expect(model.date).to be_nil
       end
 
       it "a DateTime attribute returns nil" do
         model.date_time = nil
-        model.date_time.should be_nil
+        expect(model.date_time).to be_nil
       end
 
       it "a Float attribute returns nil" do
         model.float = nil
-        model.float.should be_nil
+        expect(model.float).to be_nil
       end
 
       it "an Integer attribute returns nil" do
         model.integer = nil
-        model.integer.should be_nil
+        expect(model.integer).to be_nil
       end
 
       it "a String attribute returns nil" do
         model.string = nil
-        model.string.should be_nil
+        expect(model.string).to be_nil
       end
     end
 
@@ -89,59 +89,59 @@ module ActiveAttr
       it "a typeless attribute returns the original String" do
         value = "test"
         model.typeless = value
-        model.typeless.should equal value
+        expect(model.typeless).to equal value
       end
 
       it "an Object attribute returns the original String" do
         value = "test"
         model.object = value
-        model.object.should equal value
+        expect(model.object).to equal value
       end
 
       it "a BigDecimal attribute returns a BigDecimal" do
         model.big_decimal = "1.1"
-        model.big_decimal.should eql BigDecimal.new("1.1")
+        expect(model.big_decimal).to eql BigDecimal.new("1.1")
       end
 
       it "a Boolean attribute returns a Boolean" do
         model.boolean = "false"
-        model.boolean.should eql false
+        expect(model.boolean).to eql false
       end
 
       it "a Date attribute returns a Date" do
         model.date = "2012-01-01"
-        model.date.should eql Date.new(2012, 1, 1)
+        expect(model.date).to eql Date.new(2012, 1, 1)
       end
 
       it "a Date attribute before typecasting returns the original String" do
         value = "2012-01-01"
         model.date = value
-        model.date_before_type_cast.should equal value
+        expect(model.date_before_type_cast).to equal value
       end
 
       it "a DateTime attribute returns a DateTime" do
         model.date_time = "2012-01-01"
-        model.date_time.should eql DateTime.new(2012, 1, 1)
+        expect(model.date_time).to eql DateTime.new(2012, 1, 1)
       end
 
       it "a Float attribute returns a Float" do
         model.float = "1.1"
-        model.float.should eql 1.1
+        expect(model.float).to eql 1.1
       end
 
       it "an Integer attribute returns an Integer" do
         model.integer = "1"
-        model.integer.should eql 1
+        expect(model.integer).to eql 1
       end
 
       it "a String attribute returns the String" do
         model.string = "1.0"
-        model.string.should eql "1.0"
+        expect(model.string).to eql "1.0"
       end
 
       it "an attribute using an inline typecaster returns the result of the inline typecaster" do
         model.age = 2
-        model.age.should == Age.new(2)
+        expect(model.age).to eq(Age.new(2))
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,12 +16,7 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
-  config.expect_with :rspec do |expectations|
-    expectations.syntax = [:expect, :should]
-  end
-
   config.mock_with :rspec do |mocks|
-    mocks.syntax = :should
     mocks.verify_partial_doubles = true
   end
 end

--- a/spec/support/mass_assignment_shared_examples.rb
+++ b/spec/support/mass_assignment_shared_examples.rb
@@ -17,8 +17,8 @@ shared_examples "mass assignment class", :mass_assignment => true do
   let(:last_name) { "Griego" }
 
   def should_assign_names_to(person)
-    person.first_name.should eq first_name
-    person.last_name.should == last_name
+    expect(person.first_name).to eq first_name
+    expect(person.last_name).to eq(last_name)
   end
 end
 
@@ -89,7 +89,7 @@ shared_examples "#initialize", :initialize => true do
   end
 
   it "invokes the superclass initializer" do
-    model_class.new.should be_initialized
+    expect(model_class.new).to be_initialized
   end
 
   it "raises ArgumentError when called with three arguments" do

--- a/spec/unit/active_attr/attribute_defaults_spec.rb
+++ b/spec/unit/active_attr/attribute_defaults_spec.rb
@@ -18,25 +18,25 @@ module ActiveAttr
     describe "#attribute_defaults" do
       subject(:attribute_defaults) { model_class.new.attribute_defaults }
 
-      it { should be_a_kind_of Hash }
+      it { is_expected.to be_a_kind_of Hash }
 
       it "includes declared literal string attribute defaults" do
-        attribute_defaults["first_name"].should == "John"
+        expect(attribute_defaults["first_name"]).to eq("John")
       end
 
       it "includes declared nil attribute defaults" do
-        attribute_defaults.should include "age"
-        attribute_defaults["age"].should be_nil
+        expect(attribute_defaults).to include "age"
+        expect(attribute_defaults["age"]).to be_nil
       end
 
       it "includes declared dynamic attribute defaults" do
-        attribute_defaults["created_at"].should be_a_kind_of Time
+        expect(attribute_defaults["created_at"]).to be_a_kind_of Time
       end
     end
 
     describe "#initialize" do
       it "invokes the superclass initializer" do
-        should be_initialized
+        is_expected.to be_initialized
       end
     end
   end

--- a/spec/unit/active_attr/attribute_definition_spec.rb
+++ b/spec/unit/active_attr/attribute_definition_spec.rb
@@ -7,39 +7,39 @@ module ActiveAttr
 
     describe "#<=>" do
       it "is nil if the right side is not an #{described_class}" do
-        (attribute_definition <=> nil).should be_nil
+        expect(attribute_definition <=> nil).to be_nil
       end
 
       it "prefers neither when both sides use the same attribute name and options" do
-        (attribute_definition <=> attribute_definition).should == 0
+        expect(attribute_definition <=> attribute_definition).to eq(0)
       end
 
       it "prefers the left side when the left side name sorts alphabetically before the right side name" do
-        (described_class.new(:amount) <=> described_class.new(:quantity)).should == -1
+        expect(described_class.new(:amount) <=> described_class.new(:quantity)).to eq(-1)
       end
 
       it "prefers the right side when the right side name sorts alphabetically before the left side name" do
-        (described_class.new(:quantity) <=> described_class.new(:amount)).should == 1
+        expect(described_class.new(:quantity) <=> described_class.new(:amount)).to eq(1)
       end
     end
 
     describe "#==" do
       it "returns true when the attribute name is equal" do
-        described_class.new(:amount).should == described_class.new(:amount)
+        expect(described_class.new(:amount)).to eq(described_class.new(:amount))
       end
 
       it "returns false when another object is compared" do
-        described_class.new(:amount).should_not == Struct.new(:name).new(:amount)
+        expect(described_class.new(:amount)).not_to eq(Struct.new(:name).new(:amount))
       end
 
       it "returns false when options differ" do
-        described_class.new(:amount).should_not == described_class.new(:amount, :type => String)
+        expect(described_class.new(:amount)).not_to eq(described_class.new(:amount, :type => String))
       end
     end
 
     describe "#[]" do
       it "reads an attribute option" do
-        attribute_definition[:default].should == "default"
+        expect(attribute_definition[:default]).to eq("default")
       end
     end
 
@@ -49,11 +49,11 @@ module ActiveAttr
       end
 
       it "assigns the first argument to name" do
-        described_class.new(:amount).name.should == :amount
+        expect(described_class.new(:amount).name).to eq(:amount)
       end
 
       it "converts a String attribute name to a Symbol" do
-        described_class.new('amount').name.should == :amount
+        expect(described_class.new('amount').name).to eq(:amount)
       end
 
       it "raises a TypeError when the attribute name does not respond to #to_sym" do
@@ -63,41 +63,41 @@ module ActiveAttr
 
     describe "#inspect" do
       it "generates attribute definition code for an attribute without options" do
-        described_class.new(:first_name).inspect.should == %{attribute :first_name}
+        expect(described_class.new(:first_name).inspect).to eq(%{attribute :first_name})
       end
 
       it "generates attribute definition code for an attribute with a single option" do
-        described_class.new(:first_name, :type => String).inspect.should == %{attribute :first_name, :type => String}
+        expect(described_class.new(:first_name, :type => String).inspect).to eq(%{attribute :first_name, :type => String})
       end
 
       it "generates attribute definition code for an attribute with a single option, inspecting the option value" do
-        described_class.new(:first_name, :default => "John").inspect.should == %{attribute :first_name, :default => "John"}
+        expect(described_class.new(:first_name, :default => "John").inspect).to eq(%{attribute :first_name, :default => "John"})
       end
 
       it "generates attribute definition code for an attribute with multiple options sorted alphabetically" do
         expected = %{attribute :first_name, :default => "John", :type => String}
-        described_class.new(:first_name, :default => "John", :type => String).inspect.should eq expected
-        described_class.new(:first_name, :type => String, :default => "John").inspect.should == expected
+        expect(described_class.new(:first_name, :default => "John", :type => String).inspect).to eq expected
+        expect(described_class.new(:first_name, :type => String, :default => "John").inspect).to eq(expected)
       end
 
       it "generate attribute definition code for an attribute with a string option key" do
-        described_class.new(:first_name, "foo" => "bar").inspect.should == %{attribute :first_name, "foo" => "bar"}
+        expect(described_class.new(:first_name, "foo" => "bar").inspect).to eq(%{attribute :first_name, "foo" => "bar"})
       end
     end
 
     describe "#name" do
-      it { should respond_to(:name) }
+      it { is_expected.to respond_to(:name) }
     end
 
     describe "#to_s" do
       it "renders the name as a String" do
-        attribute_definition.to_s.should == "amount"
+        expect(attribute_definition.to_s).to eq("amount")
       end
     end
 
     describe "#to_sym" do
       it "renders the name as a Symbol" do
-        attribute_definition.to_sym.should == :amount
+        expect(attribute_definition.to_sym).to eq(:amount)
       end
     end
   end

--- a/spec/unit/active_attr/attributes_spec.rb
+++ b/spec/unit/active_attr/attributes_spec.rb
@@ -54,46 +54,46 @@ module ActiveAttr
 
     describe ".attribute" do
       context "a dangerous attribute" do
-        before { model_class.stub(:dangerous_attribute?).and_return(true) }
+        before { allow(model_class).to receive(:dangerous_attribute?).and_return(true) }
 
         it { expect { model_class.attribute(:address) }.to raise_error DangerousAttributeError }
       end
 
       context "a harmless attribute" do
         it "creates an attribute with no options" do
-          model_class.attributes.values.should include(AttributeDefinition.new(:first_name))
+          expect(model_class.attributes.values).to include(AttributeDefinition.new(:first_name))
         end
 
         it "returns the attribute definition" do
-          model_class.attribute(:address).should == AttributeDefinition.new(:address)
+          expect(model_class.attribute(:address)).to eq(AttributeDefinition.new(:address))
         end
 
         it "defines an attribute reader that calls #attribute" do
-          model.should_receive(:attribute).with("first_name")
+          expect(model).to receive(:attribute).with("first_name")
           model.first_name
         end
 
         it "defines an attribute reader that can be called via super" do
-          model.should_receive(:attribute).with("amount")
+          expect(model).to receive(:attribute).with("amount")
           model.amount
         end
 
         it "defines an attribute writer that calls #attribute=" do
-          model.should_receive(:attribute=).with("first_name", "Ben")
+          expect(model).to receive(:attribute=).with("first_name", "Ben")
           model.first_name = "Ben"
         end
 
         it "defines an attribute writer that can be called via super" do
-          model.should_receive(:attribute=).with("amount", 1)
+          expect(model).to receive(:attribute=).with("amount", 1)
           model.amount = 1
         end
 
         it "defining an attribute twice does not give the class two attribute definitions" do
-          Class.new do
+          expect(Class.new do
             include Attributes
             attribute :name
             attribute :name
-          end.attributes.size.should == 1
+          end.attributes.size).to eq(1)
         end
 
         it "redefining an attribute replaces the attribute definition" do
@@ -103,8 +103,8 @@ module ActiveAttr
             attribute :name, :type => String
           end
 
-          klass.attributes.size.should eq 1
-          klass.attributes[:name].should == AttributeDefinition.new(:name, :type => String)
+          expect(klass.attributes.size).to eq 1
+          expect(klass.attributes[:name]).to eq(AttributeDefinition.new(:name, :type => String))
         end
       end
     end
@@ -112,56 +112,56 @@ module ActiveAttr
     describe ".attribute!" do
       it "can create an attribute with no options" do
         attributeless.attribute! :first_name
-        attributeless.attributes.values.should include AttributeDefinition.new(:first_name)
+        expect(attributeless.attributes.values).to include AttributeDefinition.new(:first_name)
       end
 
       it "returns the attribute definition" do
-        attributeless.attribute!(:address).should == AttributeDefinition.new(:address)
+        expect(attributeless.attribute!(:address)).to eq(AttributeDefinition.new(:address))
       end
 
       it "defines an attribute reader that calls #attribute" do
         attributeless.attribute! :first_name
         model = attributeless.new
         result = double
-        model.should_receive(:attribute).with("first_name").and_return(result)
-        model.first_name.should equal result
+        expect(model).to receive(:attribute).with("first_name").and_return(result)
+        expect(model.first_name).to equal result
       end
 
       it "defines an attribute writer that calls #attribute=" do
         attributeless.attribute! :first_name
         model = attributeless.new
-        model.should_receive(:attribute=).with("first_name", "Ben")
+        expect(model).to receive(:attribute=).with("first_name", "Ben")
         model.first_name = "Ben"
       end
     end
 
     describe ".attributes" do
-      it { model_class.should respond_to(:attributes) }
+      it { expect(model_class).to respond_to(:attributes) }
 
       it "can access AttributeDefinition with a Symbol" do
-        model_class.attributes[:first_name].should == AttributeDefinition.new(:first_name)
+        expect(model_class.attributes[:first_name]).to eq(AttributeDefinition.new(:first_name))
       end
 
       it "can access AttributeDefinition with a String" do
-        model_class.attributes['first_name'].should == AttributeDefinition.new(:first_name)
+        expect(model_class.attributes['first_name']).to eq(AttributeDefinition.new(:first_name))
       end
 
       context "when no attributes exist" do
-        it { attributeless.attributes.should be_empty }
+        it { expect(attributeless.attributes).to be_empty }
       end
     end
 
     describe ".inspect" do
       it "renders the class name" do
-        model_class.inspect.should match(/^Foo\(.*\)$/)
+        expect(model_class.inspect).to match(/^Foo\(.*\)$/)
       end
 
       it "renders the attribute names in alphabetical order" do
-        model_class.inspect.should match "(amount, first_name, last_name)"
+        expect(model_class.inspect).to match "(amount, first_name, last_name)"
       end
 
       it "doesn't format the inspection string for attributes if the model does not have any" do
-        attributeless.inspect.should == "Foo"
+        expect(attributeless.inspect).to eq("Foo")
       end
     end
 
@@ -169,40 +169,40 @@ module ActiveAttr
       subject { model_class.new("Ben") }
 
       it "returns true when all attributes are equal" do
-        should == model_class.new("Ben")
+        is_expected.to eq(model_class.new("Ben"))
       end
 
       it "returns false when compared to another type" do
-        should_not == Struct.new(:attributes).new("first_name" => "Ben")
+        is_expected.not_to eq(Struct.new(:attributes).new("first_name" => "Ben"))
       end
     end
 
     describe "#attributes" do
       context "when no attributes are defined" do
         it "returns an empty Hash" do
-          attributeless.new.attributes.should == {}
+          expect(attributeless.new.attributes).to eq({})
         end
       end
 
       context "when an attribute is defined" do
         it "returns the key value pairs" do
           model.first_name = "Ben"
-          model.attributes.should include("first_name" => "Ben")
+          expect(model.attributes).to include("first_name" => "Ben")
         end
 
         it "returns a new Hash " do
           model.attributes.merge!("first_name" => "Bob")
-          model.attributes.should_not include("first_name" => "Bob")
+          expect(model.attributes).not_to include("first_name" => "Bob")
         end
 
         it "returns all attributes" do
-          model.attributes.keys.should =~ %w(amount first_name last_name)
+          expect(model.attributes.keys).to match_array(%w(amount first_name last_name))
         end
       end
 
       context "when a getter is overridden" do
         it "uses the overridden implementation" do
-          model.attributes.should include("last_name" => last_name)
+          expect(model.attributes).to include("last_name" => last_name)
         end
       end
     end
@@ -211,16 +211,16 @@ module ActiveAttr
       before { model.first_name = "Ben" }
 
       it "includes the class name and all attribute values in alphabetical order by attribute name" do
-        model.inspect.should == %{#<Foo amount: nil, first_name: "Ben", last_name: "#{last_name}">}
+        expect(model.inspect).to eq(%{#<Foo amount: nil, first_name: "Ben", last_name: "#{last_name}">})
       end
 
       it "doesn't format the inspection string for attributes if the model does not have any" do
-        attributeless.new.inspect.should == %{#<Foo>}
+        expect(attributeless.new.inspect).to eq(%{#<Foo>})
       end
 
       context "when a getter is overridden" do
         it "uses the overridden implementation" do
-          model.inspect.should include %{last_name: "#{last_name}"}
+          expect(model.inspect).to include %{last_name: "#{last_name}"}
         end
       end
     end
@@ -229,7 +229,7 @@ module ActiveAttr
       describe "##{method}" do
         context "when an attribute is not set" do
           it "returns nil" do
-            model.send(method, :first_name).should be_nil
+            expect(model.send(method, :first_name)).to be_nil
           end
         end
 
@@ -239,17 +239,17 @@ module ActiveAttr
           before { model.write_attribute(:first_name, first_name) }
 
           it "returns the attribute using a Symbol" do
-            model.send(method, :first_name).should == first_name
+            expect(model.send(method, :first_name)).to eq(first_name)
           end
 
           it "returns the attribute using a String" do
-            model.send(method, 'first_name').should == first_name
+            expect(model.send(method, 'first_name')).to eq(first_name)
           end
         end
 
         context "when the getter is overridden" do
           it "uses the overridden implementation" do
-            model.send(method, :last_name).should == last_name
+            expect(model.send(method, :last_name)).to eq(last_name)
           end
         end
 
@@ -285,7 +285,7 @@ module ActiveAttr
         end
 
         it "uses the overridden implementation when the setter is overridden" do
-          model.send(method, :last_name, "poweski").should == "POWESKI"
+          expect(model.send(method, :last_name, "poweski")).to eq("POWESKI")
         end
 
         it "raises when setting an undefined attribute" do

--- a/spec/unit/active_attr/block_initialization_spec.rb
+++ b/spec/unit/active_attr/block_initialization_spec.rb
@@ -18,7 +18,7 @@ module ActiveAttr
 
     describe "#initialize" do
       it "invokes the superclass initializer" do
-        should be_initialized
+        is_expected.to be_initialized
       end
 
       it "doesn't raise when not passed a block" do
@@ -32,7 +32,7 @@ module ActiveAttr
           yielded_instance = yielded
         end
 
-        returned_instance.should equal yielded_instance
+        expect(returned_instance).to equal yielded_instance
       end
     end
   end

--- a/spec/unit/active_attr/dangerous_attribute_error_spec.rb
+++ b/spec/unit/active_attr/dangerous_attribute_error_spec.rb
@@ -3,7 +3,7 @@ require "active_attr/dangerous_attribute_error"
 
 module ActiveAttr
   describe DangerousAttributeError do
-    it { should be_a_kind_of ScriptError }
-    it { should be_a_kind_of Error }
+    it { is_expected.to be_a_kind_of ScriptError }
+    it { is_expected.to be_a_kind_of Error }
   end
 end

--- a/spec/unit/active_attr/error_spec.rb
+++ b/spec/unit/active_attr/error_spec.rb
@@ -3,6 +3,6 @@ require "active_attr/error"
 
 module ActiveAttr
   describe Error do
-    it { should be_a_kind_of Module }
+    it { is_expected.to be_a_kind_of Module }
   end
 end

--- a/spec/unit/active_attr/logger_spec.rb
+++ b/spec/unit/active_attr/logger_spec.rb
@@ -16,27 +16,27 @@ module ActiveAttr
 
     context "when the logger is not set" do
       it "#{described_class}.logger is nil" do
-        described_class.logger.should be_nil
+        expect(described_class.logger).to be_nil
       end
 
       it "#{described_class}.logger? is false" do
-        described_class.logger?.should == false
+        expect(described_class.logger?).to eq(false)
       end
 
       it ".logger is nil" do
-        model_class.logger.should be_nil
+        expect(model_class.logger).to be_nil
       end
 
       it ".logger? is false" do
-        model_class.logger?.should == false
+        expect(model_class.logger?).to eq(false)
       end
 
       it "#logger is nil" do
-        model.logger.should be_nil
+        expect(model.logger).to be_nil
       end
 
       it "#logger? is false" do
-        model.logger?.should == false
+        expect(model.logger?).to eq(false)
       end
     end
 
@@ -45,27 +45,27 @@ module ActiveAttr
       after { described_class.logger = nil }
 
       it "#{described_class}.logger is the logger" do
-        described_class.logger.should == logger
+        expect(described_class.logger).to eq(logger)
       end
 
       it "#{described_class}.logger? is true" do
-        described_class.logger?.should == true
+        expect(described_class.logger?).to eq(true)
       end
 
       it ".logger is the logger" do
-        model_class.logger.should == logger
+        expect(model_class.logger).to eq(logger)
       end
 
       it ".logger? is true" do
-        model_class.logger?.should == true
+        expect(model_class.logger?).to eq(true)
       end
 
       it "#logger is the logger" do
-        model.logger.should == logger
+        expect(model.logger).to eq(logger)
       end
 
       it "#logger? is true" do
-        model.logger?.should == true
+        expect(model.logger?).to eq(true)
       end
     end
 
@@ -73,27 +73,27 @@ module ActiveAttr
       before { model_class.logger = logger }
 
       it "#{described_class}.logger is nil" do
-        described_class.logger.should be_nil
+        expect(described_class.logger).to be_nil
       end
 
       it "#{described_class}.logger? is false" do
-        described_class.logger?.should == false
+        expect(described_class.logger?).to eq(false)
       end
 
       it ".logger is the logger" do
-        model_class.logger.should == logger
+        expect(model_class.logger).to eq(logger)
       end
 
       it ".logger? is true" do
-        model_class.logger?.should == true
+        expect(model_class.logger?).to eq(true)
       end
 
       it "#logger is the logger" do
-        model.logger.should == logger
+        expect(model.logger).to eq(logger)
       end
 
       it "#logger? is true" do
-        model.logger?.should == true
+        expect(model.logger?).to eq(true)
       end
     end
 
@@ -102,27 +102,27 @@ module ActiveAttr
       subject(:model) { child_class.new }
 
       it "#{described_class}.logger is nil" do
-        described_class.logger.should be_nil
+        expect(described_class.logger).to be_nil
       end
 
       it "#{described_class}.logger? is false" do
-        described_class.logger?.should == false
+        expect(described_class.logger?).to eq(false)
       end
 
       it ".logger is the logger" do
-        child_class.logger.should == logger
+        expect(child_class.logger).to eq(logger)
       end
 
       it ".logger? is true" do
-        child_class.logger?.should == true
+        expect(child_class.logger?).to eq(true)
       end
 
       it "#logger is the logger" do
-        model.logger.should == logger
+        expect(model.logger).to eq(logger)
       end
 
       it "#logger? is true" do
-        model.logger?.should == true
+        expect(model.logger?).to eq(true)
       end
     end
 
@@ -131,27 +131,27 @@ module ActiveAttr
       subject(:model) { parent_class.new }
 
       it "#{described_class}.logger is nil" do
-        described_class.logger.should be_nil
+        expect(described_class.logger).to be_nil
       end
 
       it "#{described_class}.logger? is false" do
-        described_class.logger?.should == false
+        expect(described_class.logger?).to eq(false)
       end
 
       it ".logger is nil" do
-        parent_class.logger.should be_nil
+        expect(parent_class.logger).to be_nil
       end
 
       it ".logger? is false" do
-        parent_class.logger?.should == false
+        expect(parent_class.logger?).to eq(false)
       end
 
       it "#logger is nil" do
-        model.logger.should be_nil
+        expect(model.logger).to be_nil
       end
 
       it "#logger? is false" do
-        model.logger?.should == false
+        expect(model.logger?).to eq(false)
       end
     end
 
@@ -159,27 +159,27 @@ module ActiveAttr
       before { model.logger = logger }
 
       it "#{described_class}.logger is nil" do
-        described_class.logger.should be_nil
+        expect(described_class.logger).to be_nil
       end
 
       it "#{described_class}.logger? is false" do
-        described_class.logger?.should == false
+        expect(described_class.logger?).to eq(false)
       end
 
       it ".logger is nil" do
-        model_class.logger.should be_nil
+        expect(model_class.logger).to be_nil
       end
 
       it ".logger? is false" do
-        model_class.logger?.should == false
+        expect(model_class.logger?).to eq(false)
       end
 
       it "#logger is the logger" do
-        model.logger.should == logger
+        expect(model.logger).to eq(logger)
       end
 
       it "#logger? is true" do
-        model.logger?.should == true
+        expect(model.logger?).to eq(true)
       end
     end
   end

--- a/spec/unit/active_attr/mass_assignment_spec.rb
+++ b/spec/unit/active_attr/mass_assignment_spec.rb
@@ -15,13 +15,13 @@ module ActiveAttr
       it "ignores attributes which do not have a writer" do
         person = mass_assign_attributes(:middle_initial => "J")
         person.instance_eval { @middle_initial ||= nil }
-        person.instance_variable_get("@middle_initial").should be_nil
-        person.should_not respond_to :middle_initial
+        expect(person.instance_variable_get("@middle_initial")).to be_nil
+        expect(person).not_to respond_to :middle_initial
       end
 
       it "ignores trying to assign a private attribute" do
         person = mass_assign_attributes(:middle_name => "J")
-        person.middle_name.should be_nil
+        expect(person.middle_name).to be_nil
       end
     end
 

--- a/spec/unit/active_attr/matchers/have_attribute_matcher_spec.rb
+++ b/spec/unit/active_attr/matchers/have_attribute_matcher_spec.rb
@@ -5,33 +5,33 @@ module ActiveAttr
   module Matchers
     describe HaveAttributeMatcher do
       describe ".class" do
-        it { described_class.should respond_to(:new).with(1).argument }
+        it { expect(described_class).to respond_to(:new).with(1).argument }
       end
 
       describe "#description" do
         it "returns a description appropriate to the expectation" do
-          described_class.new(:first_name).description.should == "have attribute named first_name"
+          expect(described_class.new(:first_name).description).to eq("have attribute named first_name")
         end
 
         it "mentions the default value if set" do
-          described_class.new(:first_name).with_default_value_of("John").description.should == %{have attribute named first_name with a default value of "John"}
+          expect(described_class.new(:first_name).with_default_value_of("John").description).to eq(%{have attribute named first_name with a default value of "John"})
         end
 
         it "mentions the default value if set to nil" do
-          described_class.new(:first_name).with_default_value_of(nil).description.should == %{have attribute named first_name with a default value of nil}
+          expect(described_class.new(:first_name).with_default_value_of(nil).description).to eq(%{have attribute named first_name with a default value of nil})
         end
 
         it "mentions the default value if set to false" do
-          described_class.new(:admin).with_default_value_of(false).description.should == %{have attribute named admin with a default value of false}
+          expect(described_class.new(:admin).with_default_value_of(false).description).to eq(%{have attribute named admin with a default value of false})
         end
 
         it "mentions the type if set" do
-          described_class.new(:first_name).of_type(String).description.should == %{have attribute named first_name of type String}
+          expect(described_class.new(:first_name).of_type(String).description).to eq(%{have attribute named first_name of type String})
         end
 
         it "mentions both the type and default if both are set" do
           description = described_class.new(:first_name).of_type(String).with_default_value_of("John").description
-          description.should == %{have attribute named first_name of type String with a default value of "John"}
+          expect(description).to eq(%{have attribute named first_name of type String with a default value of "John"})
         end
       end
 
@@ -43,13 +43,13 @@ module ActiveAttr
 
       describe "#of_type" do
         it "chains" do
-          described_class.new(:first_name).of_type(String).should be_a_kind_of described_class
+          expect(described_class.new(:first_name).of_type(String)).to be_a_kind_of described_class
         end
       end
 
       describe "#with_default_value_of" do
         it "chains" do
-          described_class.new(:first_name).with_default_value_of(nil).should be_a_kind_of described_class
+          expect(described_class.new(:first_name).with_default_value_of(nil)).to be_a_kind_of described_class
         end
       end
     end

--- a/spec/unit/active_attr/matchers_spec.rb
+++ b/spec/unit/active_attr/matchers_spec.rb
@@ -5,17 +5,17 @@ module ActiveAttr
   describe Matchers do
     subject(:dsl) { Object.new.extend described_class }
 
-    it { should respond_to(:have_attribute).with(1).argument }
+    it { is_expected.to respond_to(:have_attribute).with(1).argument }
 
     describe "#have_attribute" do
       subject(:matcher) { dsl.have_attribute(:first_name) }
 
       it "builds a HaveAttributeMatcher" do
-        should be_a_kind_of Matchers::HaveAttributeMatcher
+        is_expected.to be_a_kind_of Matchers::HaveAttributeMatcher
       end
 
       it "uses the given attribute name to construct the matcher" do
-        matcher.send(:attribute_name).should == :first_name
+        expect(matcher.send(:attribute_name)).to eq(:first_name)
       end
     end
   end

--- a/spec/unit/active_attr/query_attributes_spec.rb
+++ b/spec/unit/active_attr/query_attributes_spec.rb
@@ -29,12 +29,12 @@ module ActiveAttr
 
     describe ".attribute" do
       it "defines an attribute predicate method that calls #attribute?" do
-        model.should_receive(:attribute?).with("value")
+        expect(model).to receive(:attribute?).with("value")
         model.value?
       end
 
       it "defines an attribute reader that can be called via super" do
-        model.should_receive(:attribute?).with("overridden")
+        expect(model).to receive(:attribute?).with("overridden")
         model.overridden?
       end
     end
@@ -53,8 +53,8 @@ module ActiveAttr
       end
 
       it "calls the predicate method if defined" do
-        model.query_attribute(:true).should eq true
-        model.query_attribute(:false).should == false
+        expect(model.query_attribute(:true)).to eq true
+        expect(model.query_attribute(:false)).to eq(false)
       end
 
       it "raises when getting an undefined attribute" do
@@ -63,162 +63,162 @@ module ActiveAttr
 
       it "is false when the attribute is false" do
         model.value = false
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is true" do
         model.value = true
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is nil" do
         model.value = nil
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is an Object" do
         model.value = Object.new
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is an empty string" do
         model.value = ""
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is a non-empty string" do
         model.value = "Chris"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is 0" do
         model.value = 0
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is 1" do
         model.value = 1
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is 0.0" do
         model.value = 0.0
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is 0.1" do
         model.value = 0.1
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is a zero BigDecimal" do
         model.value = BigDecimal.new("0.0")
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is a non-zero BigDecimal" do
         model.value = BigDecimal.new("0.1")
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is true when the attribute is -1" do
         model.value = -1
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is -0.0" do
         model.value = -0.0
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is -0.1" do
         model.value = -0.1
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is a negative zero BigDecimal" do
         model.value = BigDecimal.new("-0.0")
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is a negative BigDecimal" do
         model.value = BigDecimal.new("-0.1")
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is '0'" do
         model.value = "0"
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is '1'" do
         model.value = "1"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is '0.0'" do
         model.value = "0.0"
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is '0.1'" do
         model.value = "0.1"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is true when the attribute is '-1'" do
         model.value = "-1"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is '-0.0'" do
         model.value = "-0.0"
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is '-0.1'" do
         model.value = "-0.1"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is true when the attribute is 'true'" do
         model.value = "true"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is 'false'" do
         model.value = "false"
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is 't'" do
         model.value = "t"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is 'f'" do
         model.value = "f"
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is 'T'" do
         model.value = "T"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is 'F'" do
         model.value = "F"
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
 
       it "is true when the attribute is 'TRUE'" do
         model.value = "TRUE"
-        model.value?.should == true
+        expect(model.value?).to eq(true)
       end
 
       it "is false when the attribute is 'FALSE" do
         model.value = "FALSE"
-        model.value?.should == false
+        expect(model.value?).to eq(false)
       end
     end
   end

--- a/spec/unit/active_attr/typecasted_attributes_spec.rb
+++ b/spec/unit/active_attr/typecasted_attributes_spec.rb
@@ -35,45 +35,45 @@ module ActiveAttr
 
     describe ".attribute" do
       it "defines an attribute pre-typecasting reader that calls #attribute_before_type_cast" do
-        model.should_receive(:attribute_before_type_cast).with("first_name")
+        expect(model).to receive(:attribute_before_type_cast).with("first_name")
         model.first_name_before_type_cast
       end
 
       it "defines an attribute reader that can be called via super" do
-        model.should_receive(:attribute_before_type_cast).with("last_name")
+        expect(model).to receive(:attribute_before_type_cast).with("last_name")
         model.last_name_before_type_cast
       end
     end
 
     describe ".inspect" do
       it "renders the class name" do
-        model_class.inspect.should match(/^Foo\(.*\)$/)
+        expect(model_class.inspect).to match(/^Foo\(.*\)$/)
       end
 
       it "renders the attribute names and types in alphabetical order, using Object for undeclared types" do
-        model_class.inspect.should match "(amount: String, first_name: Object, last_name: Object)"
+        expect(model_class.inspect).to match "(amount: String, first_name: Object, last_name: Object)"
       end
 
       it "doesn't format the inspection string for attributes if the model does not have any" do
-        attributeless.inspect.should == "Foo"
+        expect(attributeless.inspect).to eq("Foo")
       end
     end
 
     describe "#attribute_before_type_cast" do
       it "returns nil when the attribute has not been assigned yet" do
-        model.attribute_before_type_cast(:amount).should be_nil
+        expect(model.attribute_before_type_cast(:amount)).to be_nil
       end
 
       it "returns the assigned attribute value, without typecasting, when given an attribute name as a Symbol" do
         value = :value
         model.amount = value
-        model.attribute_before_type_cast(:amount).should equal value
+        expect(model.attribute_before_type_cast(:amount)).to equal value
       end
 
       it "returns the assigned attribute value, without typecasting, when given an attribute name as a String" do
         value = :value
         model.amount = value
-        model.attribute_before_type_cast('amount').should equal value
+        expect(model.attribute_before_type_cast('amount')).to equal value
       end
     end
   end

--- a/spec/unit/active_attr/typecasting/big_decimal_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/big_decimal_typecaster_spec.rb
@@ -9,31 +9,31 @@ module ActiveAttr
       describe "#call" do
         it "returns the original BigDecimal for a BigDecimal" do
           value = BigDecimal.new("2.0")
-          typecaster.call(value).should equal value
+          expect(typecaster.call(value)).to equal value
         end
 
         it "casts nil to a zero BigDecimal" do
-          typecaster.call(nil).should eql BigDecimal.new("0.0")
+          expect(typecaster.call(nil)).to eql BigDecimal.new("0.0")
         end
 
         it "casts a numeric String to a BigDecimal" do
-          typecaster.call("2").should eql BigDecimal.new("2.0")
+          expect(typecaster.call("2")).to eql BigDecimal.new("2.0")
         end
 
         it "casts a alpha String to a zero BigDecimal" do
-          typecaster.call("bob").should eql BigDecimal.new("0.0")
+          expect(typecaster.call("bob")).to eql BigDecimal.new("0.0")
         end
 
         it "casts a Rational to a BigDecimal" do
-          typecaster.call(Rational(1, 2)).should eql BigDecimal.new("0.5")
+          expect(typecaster.call(Rational(1, 2))).to eql BigDecimal.new("0.5")
         end
 
         it "casts a Float to a BigDecimal" do
-          typecaster.call(1.2).should eql BigDecimal.new("1.2")
+          expect(typecaster.call(1.2)).to eql BigDecimal.new("1.2")
         end
 
         it "cases an Integer to a BigDecimal" do
-          typecaster.call(2).should eql BigDecimal.new("2.0")
+          expect(typecaster.call(2)).to eql BigDecimal.new("2.0")
         end
       end
     end

--- a/spec/unit/active_attr/typecasting/boolean_spec.rb
+++ b/spec/unit/active_attr/typecasting/boolean_spec.rb
@@ -4,7 +4,7 @@ require "active_attr/typecasting/boolean"
 module ActiveAttr
   module Typecasting
     describe Boolean do
-      it { described_class.should be_a Class }
+      it { expect(described_class).to be_a Class }
     end
   end
 end

--- a/spec/unit/active_attr/typecasting/boolean_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/boolean_typecaster_spec.rb
@@ -9,28 +9,28 @@ module ActiveAttr
 
       describe "#call" do
         it "returns true for true" do
-          typecaster.call(true).should equal true
+          expect(typecaster.call(true)).to equal true
         end
 
         it "returns false for false" do
-          typecaster.call(false).should equal false
+          expect(typecaster.call(false)).to equal false
         end
 
         it "casts nil to false" do
-          typecaster.call(nil).should equal false
+          expect(typecaster.call(nil)).to equal false
         end
 
         it "casts an Object to true" do
-          typecaster.call(Object.new).should equal true
+          expect(typecaster.call(Object.new)).to equal true
         end
 
         context "when the value is a String" do
           it "casts an empty String to false" do
-            typecaster.call("").should equal false
+            expect(typecaster.call("")).to equal false
           end
 
           it "casts a non-empty String to true" do
-            typecaster.call("abc").should equal true
+            expect(typecaster.call("abc")).to equal true
           end
 
           {
@@ -63,84 +63,84 @@ module ActiveAttr
             "OFF" => false,
           }.each_pair do |value, result|
             it "casts #{value.inspect} to #{result.inspect}" do
-              typecaster.call(value).should equal result
+              expect(typecaster.call(value)).to equal result
             end
           end
         end
 
         context "when the value is Numeric" do
           it "casts 0 to false" do
-            typecaster.call(0).should equal false
+            expect(typecaster.call(0)).to equal false
           end
 
           it "casts 1 to true" do
-            typecaster.call(1).should equal true
+            expect(typecaster.call(1)).to equal true
           end
 
           it "casts 0.0 to false" do
-            typecaster.call(0.0).should equal false
+            expect(typecaster.call(0.0)).to equal false
           end
 
           it "casts 0.1 to true" do
-            typecaster.call(0.1).should equal true
+            expect(typecaster.call(0.1)).to equal true
           end
 
           it "casts a zero BigDecimal to false" do
-            typecaster.call(BigDecimal.new("0.0")).should equal false
+            expect(typecaster.call(BigDecimal.new("0.0"))).to equal false
           end
 
           it "casts a non-zero BigDecimal to true" do
-            typecaster.call(BigDecimal.new("0.1")).should equal true
+            expect(typecaster.call(BigDecimal.new("0.1"))).to equal true
           end
 
           it "casts -1 to true" do
-            typecaster.call(-1).should equal true
+            expect(typecaster.call(-1)).to equal true
           end
 
           it "casts -0.0 to false" do
-            typecaster.call(-0.0).should equal false
+            expect(typecaster.call(-0.0)).to equal false
           end
 
           it "casts -0.1 to true" do
-            typecaster.call(-0.1).should equal true
+            expect(typecaster.call(-0.1)).to equal true
           end
 
           it "casts a negative zero BigDecimal to false" do
-            typecaster.call(BigDecimal.new("-0.0")).should equal false
+            expect(typecaster.call(BigDecimal.new("-0.0"))).to equal false
           end
 
           it "casts a negative BigDecimal to true" do
-            typecaster.call(BigDecimal.new("-0.1")).should equal true
+            expect(typecaster.call(BigDecimal.new("-0.1"))).to equal true
           end
         end
 
         context "when the value is the String version of a Numeric" do
           it "casts '0' to false" do
-            typecaster.call("0").should equal false
+            expect(typecaster.call("0")).to equal false
           end
 
           it "casts '1' to true" do
-            typecaster.call("1").should equal true
+            expect(typecaster.call("1")).to equal true
           end
 
           it "casts '0.0' to false" do
-            typecaster.call("0.0").should equal false
+            expect(typecaster.call("0.0")).to equal false
           end
 
           it "casts '0.1' to true" do
-            typecaster.call("0.1").should equal true
+            expect(typecaster.call("0.1")).to equal true
           end
 
           it "casts '-1' to true" do
-            typecaster.call("-1").should equal true
+            expect(typecaster.call("-1")).to equal true
           end
 
           it "casts '-0.0' to false" do
-            typecaster.call("-0.0").should equal false
+            expect(typecaster.call("-0.0")).to equal false
           end
 
           it "casts '-0.1' to true" do
-            typecaster.call("-0.1").should equal true
+            expect(typecaster.call("-0.1")).to equal true
           end
         end
       end

--- a/spec/unit/active_attr/typecasting/date_time_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/date_time_typecaster_spec.rb
@@ -9,60 +9,60 @@ module ActiveAttr
       describe "#call" do
         it "returns the original DateTime for a DateTime" do
           value = DateTime.now
-          typecaster.call(value).should equal value
+          expect(typecaster.call(value)).to equal value
         end
 
         it "returns nil for nil" do
-          typecaster.call(nil).should equal nil
+          expect(typecaster.call(nil)).to equal nil
         end
 
         it "casts a Date to a DateTime at the beginning of the day with no offset" do
           result = typecaster.call(Date.new(2012, 1, 1))
-          result.should eql DateTime.new(2012, 1, 1)
-          result.should be_instance_of DateTime
+          expect(result).to eql DateTime.new(2012, 1, 1)
+          expect(result).to be_instance_of DateTime
         end
 
         it "casts a UTC Time to a DateTime with no offset" do
           result = typecaster.call(Time.utc(2012, 1, 1, 12, 0, 0))
-          result.should eql DateTime.new(2012, 1, 1, 12, 0, 0, 0)
-          result.should be_instance_of DateTime
+          expect(result).to eql DateTime.new(2012, 1, 1, 12, 0, 0, 0)
+          expect(result).to be_instance_of DateTime
         end
 
         it "casts a local Time to a DateTime with a matching offset" do
           value = Time.local(2012, 1, 1, 12, 0, 0)
           result = typecaster.call(value)
-          result.should eql DateTime.new(2012, 1, 1, 12, 0, 0, Rational(value.utc_offset, 86400))
-          result.should be_instance_of DateTime
+          expect(result).to eql DateTime.new(2012, 1, 1, 12, 0, 0, Rational(value.utc_offset, 86400))
+          expect(result).to be_instance_of DateTime
         end
 
         it "casts an ISO8601 date String to a Date" do
           result = typecaster.call("2012-01-01")
-          result.should eql DateTime.new(2012, 1, 1)
-          result.should be_instance_of DateTime
+          expect(result).to eql DateTime.new(2012, 1, 1)
+          expect(result).to be_instance_of DateTime
         end
 
         it "casts an RFC2616 date and GMT time String to a DateTime" do
           result = typecaster.call("Sat, 03 Feb 2001 00:00:00 GMT")
-          result.should eql DateTime.new(2001, 2, 3)
-          result.should be_instance_of DateTime
+          expect(result).to eql DateTime.new(2001, 2, 3)
+          expect(result).to be_instance_of DateTime
         end
 
         it "casts an RFC3339 date and offset time String to a DateTime" do
           result = typecaster.call("2001-02-03T04:05:06+07:00")
-          result.should eql DateTime.new(2001, 2, 3, 4, 5, 6, "+07:00")
-          result.should be_instance_of DateTime
+          expect(result).to eql DateTime.new(2001, 2, 3, 4, 5, 6, "+07:00")
+          expect(result).to be_instance_of DateTime
         end
 
         it "casts a UTC ActiveSupport::TimeWithZone to a DateTime" do
           result = typecaster.call(Time.utc(2012, 1, 1, 1, 1, 1).in_time_zone("UTC"))
-          result.should eql DateTime.new(2012, 1, 1, 1, 1, 1, 0)
-          result.should be_instance_of DateTime
+          expect(result).to eql DateTime.new(2012, 1, 1, 1, 1, 1, 0)
+          expect(result).to be_instance_of DateTime
         end
 
         it "casts an Alaska ActiveSupport::TimeWithZone to a Date representing the date portion" do
           result = typecaster.call(Time.utc(2012, 1, 1, 0, 0, 0).in_time_zone("Alaska"))
-          result.should eql DateTime.new(2011, 12, 31, 15, 0, 0, "-09:00")
-          result.should be_instance_of DateTime
+          expect(result).to eql DateTime.new(2011, 12, 31, 15, 0, 0, "-09:00")
+          expect(result).to be_instance_of DateTime
         end
       end
     end

--- a/spec/unit/active_attr/typecasting/date_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/date_typecaster_spec.rb
@@ -9,51 +9,51 @@ module ActiveAttr
       describe "#call" do
         it "returns the original date for a Date" do
           value = Date.today
-          typecaster.call(value).should equal value
+          expect(typecaster.call(value)).to equal value
         end
 
         it "returns nil for nil" do
-          typecaster.call(nil).should equal nil
+          expect(typecaster.call(nil)).to equal nil
         end
 
         it "returns nil for an invalid String" do
-          typecaster.call("x").should equal nil
+          expect(typecaster.call("x")).to equal nil
         end
 
         it "casts a UTC Time to a Date representing the date portion" do
-          typecaster.call(Time.utc(2012, 1, 1, 0, 0, 0)).should eql Date.new(2012, 1, 1)
+          expect(typecaster.call(Time.utc(2012, 1, 1, 0, 0, 0))).to eql Date.new(2012, 1, 1)
         end
 
         it "casts a local Time to a Date representing the date portion" do
-          typecaster.call(Time.local(2012, 1, 1, 0, 0, 0)).should eql Date.new(2012, 1, 1)
+          expect(typecaster.call(Time.local(2012, 1, 1, 0, 0, 0))).to eql Date.new(2012, 1, 1)
         end
 
         it "casts a UTC DateTime to a Date representing the date portion" do
-          typecaster.call(DateTime.new(2012, 1, 1, 0, 0, 0)).should eql Date.new(2012, 1, 1)
+          expect(typecaster.call(DateTime.new(2012, 1, 1, 0, 0, 0))).to eql Date.new(2012, 1, 1)
         end
 
         it "casts an offset DateTime to a Date representing the date portion" do
-          typecaster.call(DateTime.new(2012, 1, 1, 0, 0, 0, "-12:00")).should eql Date.new(2012, 1, 1)
+          expect(typecaster.call(DateTime.new(2012, 1, 1, 0, 0, 0, "-12:00"))).to eql Date.new(2012, 1, 1)
         end
 
         it "casts an ISO8601 date String to a Date" do
-          typecaster.call("2012-01-01").should eql Date.new(2012, 1, 1)
+          expect(typecaster.call("2012-01-01")).to eql Date.new(2012, 1, 1)
         end
 
         it "casts an RFC2616 date and GMT time String to a Date representing the date portion" do
-          typecaster.call("Sat, 03 Feb 2001 00:00:00 GMT").should eql Date.new(2001, 2, 3)
+          expect(typecaster.call("Sat, 03 Feb 2001 00:00:00 GMT")).to eql Date.new(2001, 2, 3)
         end
 
         it "casts an RFC3339 date and offset time String to a Date representing the date portion" do
-          typecaster.call("2001-02-03T04:05:06+07:00").should eql Date.new(2001, 2, 3)
+          expect(typecaster.call("2001-02-03T04:05:06+07:00")).to eql Date.new(2001, 2, 3)
         end
 
         it "casts a UTC ActiveSupport::TimeWithZone to a Date representing the date portion" do
-          typecaster.call(Time.utc(2012, 1, 1, 0, 0, 0).in_time_zone("UTC")).should eql Date.new(2012, 1, 1)
+          expect(typecaster.call(Time.utc(2012, 1, 1, 0, 0, 0).in_time_zone("UTC"))).to eql Date.new(2012, 1, 1)
         end
 
         it "casts an Alaska ActiveSupport::TimeWithZone to a Date representing the date portion" do
-          typecaster.call(Time.utc(2012, 1, 1, 0, 0, 0).in_time_zone("Alaska")).should eql Date.new(2011, 12, 31)
+          expect(typecaster.call(Time.utc(2012, 1, 1, 0, 0, 0).in_time_zone("Alaska"))).to eql Date.new(2011, 12, 31)
         end
       end
     end

--- a/spec/unit/active_attr/typecasting/float_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/float_typecaster_spec.rb
@@ -9,19 +9,19 @@ module ActiveAttr
       describe "#call" do
         it "returns the original float for a Float" do
           value = 2.0
-          typecaster.call(value).should equal value
+          expect(typecaster.call(value)).to equal value
         end
 
         it "casts nil to 0.0" do
-          typecaster.call(nil).should eql 0.0
+          expect(typecaster.call(nil)).to eql 0.0
         end
 
         it "returns the float version of a String" do
-          typecaster.call("2").should eql 2.0
+          expect(typecaster.call("2")).to eql 2.0
         end
 
         it "returns nil for an object that does not respond to #to_f" do
-          typecaster.call(Object.new).should be_nil
+          expect(typecaster.call(Object.new)).to be_nil
         end
       end
     end

--- a/spec/unit/active_attr/typecasting/integer_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/integer_typecaster_spec.rb
@@ -9,27 +9,27 @@ module ActiveAttr
       describe "#call" do
         it "returns the original integer for a FixNum" do
           value = 2
-          typecaster.call(value).should equal value
+          expect(typecaster.call(value)).to equal value
         end
 
         it "casts nil to 0" do
-          typecaster.call(nil).should eql 0
+          expect(typecaster.call(nil)).to eql 0
         end
 
         it "returns the integer version of a String" do
-          typecaster.call("2").should eql 2
+          expect(typecaster.call("2")).to eql 2
         end
 
         it "returns nil for an object that does not respond to #to_i" do
-          typecaster.call(Object.new).should be_nil
+          expect(typecaster.call(Object.new)).to be_nil
         end
 
         it "returns nil for Float::INFINITY" do
-          typecaster.call(1.0 / 0.0).should be_nil
+          expect(typecaster.call(1.0 / 0.0)).to be_nil
         end
 
         it "returns nil for Float::NAN" do
-          typecaster.call(0.0 / 0.0).should be_nil
+          expect(typecaster.call(0.0 / 0.0)).to be_nil
         end
       end
     end

--- a/spec/unit/active_attr/typecasting/object_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/object_typecaster_spec.rb
@@ -9,7 +9,7 @@ module ActiveAttr
       describe "#call" do
         it "returns the original object for any object" do
           value = double
-          typecaster.call(value).should equal value
+          expect(typecaster.call(value)).to equal value
         end
       end
     end

--- a/spec/unit/active_attr/typecasting/string_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/string_typecaster_spec.rb
@@ -9,15 +9,15 @@ module ActiveAttr
       describe "#call" do
         it "returns the original string for a String" do
           value = "abc"
-          typecaster.call(value).should equal value
+          expect(typecaster.call(value)).to equal value
         end
 
         it "casts nil to an empty String" do
-          typecaster.call(nil).should eql ""
+          expect(typecaster.call(nil)).to eql ""
         end
 
         it "returns the string version of a Symbol" do
-          typecaster.call(:value).should eql "value"
+          expect(typecaster.call(:value)).to eql "value"
         end
       end
     end

--- a/spec/unit/active_attr/typecasting/unknown_typecaster_error_spec.rb
+++ b/spec/unit/active_attr/typecasting/unknown_typecaster_error_spec.rb
@@ -4,8 +4,8 @@ require "active_attr/typecasting/unknown_typecaster_error"
 module ActiveAttr
   module Typecasting
     describe UnknownTypecasterError do
-      it { should be_a_kind_of TypeError }
-      it { should be_a_kind_of Error }
+      it { is_expected.to be_a_kind_of TypeError }
+      it { is_expected.to be_a_kind_of Error }
     end
   end
 end

--- a/spec/unit/active_attr/typecasting_spec.rb
+++ b/spec/unit/active_attr/typecasting_spec.rb
@@ -21,41 +21,41 @@ module ActiveAttr
       end
 
       it "returns the original value when the value is nil" do
-        model_class.new.typecast_attribute(double(:call => 1), nil).should be_nil
+        expect(model_class.new.typecast_attribute(double(:call => 1), nil)).to be_nil
       end
     end
 
     describe "#typecaster_for" do
       it "returns BigDecimalTypecaster for BigDecimal" do
-        model.typecaster_for(BigDecimal).should be_a_kind_of Typecasting::BigDecimalTypecaster
+        expect(model.typecaster_for(BigDecimal)).to be_a_kind_of Typecasting::BigDecimalTypecaster
       end
 
       it "returns BooleanTypecaster for Boolean" do
-        model.typecaster_for(Typecasting::Boolean).should be_a_kind_of Typecasting::BooleanTypecaster
+        expect(model.typecaster_for(Typecasting::Boolean)).to be_a_kind_of Typecasting::BooleanTypecaster
       end
 
       it "returns DateTypecaster for Date" do
-        model.typecaster_for(Date).should be_a_kind_of Typecasting::DateTypecaster
+        expect(model.typecaster_for(Date)).to be_a_kind_of Typecasting::DateTypecaster
       end
 
       it "returns DateTypecaster for Date" do
-        model.typecaster_for(DateTime).should be_a_kind_of Typecasting::DateTimeTypecaster
+        expect(model.typecaster_for(DateTime)).to be_a_kind_of Typecasting::DateTimeTypecaster
       end
 
       it "returns FloatTypecaster for Float" do
-        model.typecaster_for(Float).should be_a_kind_of Typecasting::FloatTypecaster
+        expect(model.typecaster_for(Float)).to be_a_kind_of Typecasting::FloatTypecaster
       end
 
       it "returns IntegerTypecaster for Integer" do
-        model.typecaster_for(Integer).should be_a_kind_of Typecasting::IntegerTypecaster
+        expect(model.typecaster_for(Integer)).to be_a_kind_of Typecasting::IntegerTypecaster
       end
 
       it "returns StringTypecaster for String" do
-        model.typecaster_for(String).should be_a_kind_of Typecasting::StringTypecaster
+        expect(model.typecaster_for(String)).to be_a_kind_of Typecasting::StringTypecaster
       end
 
       it "returns ObjectTypecaster for Object" do
-        model.typecaster_for(Object).should be_a_kind_of Typecasting::ObjectTypecaster
+        expect(model.typecaster_for(Object)).to be_a_kind_of Typecasting::ObjectTypecaster
       end
     end
   end

--- a/spec/unit/active_attr/unknown_attribute_error_spec.rb
+++ b/spec/unit/active_attr/unknown_attribute_error_spec.rb
@@ -3,7 +3,7 @@ require "active_attr/unknown_attribute_error"
 
 module ActiveAttr
   describe UnknownAttributeError do
-    it { should be_a_kind_of NoMethodError }
-    it { should be_a_kind_of Error }
+    it { is_expected.to be_a_kind_of NoMethodError }
+    it { is_expected.to be_a_kind_of Error }
   end
 end

--- a/spec/unit/active_attr/version_spec.rb
+++ b/spec/unit/active_attr/version_spec.rb
@@ -5,38 +5,38 @@ module ActiveAttr
   describe "ActiveAttr::VERSION" do
     subject { VERSION }
 
-    it { should be_a_kind_of String }
+    it { is_expected.to be_a_kind_of String }
 
     describe "is compliant with Semantic Versioning <http://semver.org/>" do
       let(:gem_version) { Gem::Version.new VERSION }
       subject(:version) { gem_version }
 
-      it { version.segments.size.should >= 3 }
-      it { version.segments.size.should <= 5 }
+      it { expect(version.segments.size).to be >= 3 }
+      it { expect(version.segments.size).to be <= 5 }
 
       describe "major version" do
         subject { gem_version.segments[0] }
 
-        it { should be_a_kind_of Fixnum }
+        it { is_expected.to be_a_kind_of Fixnum }
       end
 
       describe "minor version" do
         subject { gem_version.segments[1] }
 
-        it { should be_a_kind_of Fixnum }
+        it { is_expected.to be_a_kind_of Fixnum }
       end
 
       describe "patch version" do
         subject { gem_version.segments[2] }
 
-        it { should be_a_kind_of Fixnum }
+        it { is_expected.to be_a_kind_of Fixnum }
       end
 
       describe "pre-release version" do
         subject(:pre_release_version) { VERSION.split(".")[3] }
 
         it "is nil or starts with a letter and is alphanumeric" do
-          (pre_release_version.nil? || pre_release_version =~ /^[A-Za-z][0-9A-Za-z]*?/).should == true
+          expect(pre_release_version.nil? || pre_release_version =~ /^[A-Za-z][0-9A-Za-z]*?/).to eq(true)
         end
       end
     end


### PR DESCRIPTION
This conversion is done by Transpec 3.1.1 with the following command:
    transpec -f
- 350 conversions
  from: obj.should
    to: expect(obj).to
- 179 conversions
  from: == expected
    to: eq(expected)
- 22 conversions
  from: it { should ... }
    to: it { is_expected.to ... }
- 10 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 6 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 3 conversions
  from: it { should_not ... }
    to: it { is_expected.not_to ... }
- 1 conversion
  from: <= expected
    to: be <= expected
- 1 conversion
  from: =~ [1, 2]
    to: match_array([1, 2])
- 1 conversion
  from: >= expected
    to: be >= expected
- 1 conversion
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions
