### PR TITLE
Typecast on writing

### DIFF
--- a/lib/active_attr/attribute_defaults.rb
+++ b/lib/active_attr/attribute_defaults.rb
@@ -70,8 +70,7 @@ module ActiveAttr
     def apply_defaults(defaults=attribute_defaults)
       @attributes ||= {}
       defaults.each do |name, value|
-        # instance variable is used here to avoid any dirty tracking in attribute setter methods
-        @attributes[name] = value unless @attributes.has_key? name
+        write_attribute(name, value)  unless @attributes.has_key? name
       end
     end
 

--- a/lib/active_attr/typecasted_attributes.rb
+++ b/lib/active_attr/typecasted_attributes.rb
@@ -46,17 +46,19 @@ module ActiveAttr
     #
     # @since 0.5.0
     def attribute_before_type_cast(name)
-      @attributes ||= {}
-      @attributes[name.to_s]
+      @before_type_cast_attributes ||= {}
+      @before_type_cast_attributes[name.to_s]
     end
 
     private
 
-    # Reads the attribute and typecasts the result
+    # Write the attribute and typecasts the result
     #
-    # @since 0.5.0
-    def attribute(name)
-      typecast_attribute(_attribute_typecaster(name), super)
+    # @since 0.9.0
+    def attribute=(name, value)
+      @before_type_cast_attributes ||= {}
+      @before_type_cast_attributes[name] = value
+      super(name, typecast_attribute(_attribute_typecaster(name), value))
     end
 
     # Calculates an attribute type

--- a/spec/functional/active_attr/typecasted_attributes_spec.rb
+++ b/spec/functional/active_attr/typecasted_attributes_spec.rb
@@ -35,8 +35,7 @@ module ActiveAttr
       end
 
       it "an attribute with no known typecaster raises" do
-        model.unknown = nil
-        expect { model.unknown }.to raise_error Typecasting::UnknownTypecasterError, "Unable to cast to type Unknown"
+        expect { model.unknown = nil  }.to raise_error Typecasting::UnknownTypecasterError, "Unable to cast to type Unknown"
       end
 
       it "an attribute with an inline typecaster returns nil" do


### PR DESCRIPTION
Currently, typecasting works on attribute reading. This position has two defects are:
– every reading is every typecasting.
– if typecasted class has attributes they can't be changed, because typecasting creates a new instance every time.

I suggest using typecasting on writing. It avoids from both defects