### PR TITLE
Modify `with_default_value_of` for lazy evaluation

### DIFF
--- a/lib/active_attr/matchers/have_attribute_matcher.rb
+++ b/lib/active_attr/matchers/have_attribute_matcher.rb
@@ -76,7 +76,7 @@ module ActiveAttr
         @attribute_options[:default] = default_value
         @description << " with a default value of #{default_value.inspect}"
         @expected_ancestors << "ActiveAttr::AttributeDefaults"
-        @attribute_expectations << lambda { actual_attribute_definition[:default] == default_value }
+        @attribute_expectations << lambda { _attribute_default == default_value }
         self
       end
 
@@ -128,6 +128,16 @@ module ActiveAttr
 
         @expected_ancestors.reject do |ancestor_name|
           model_ancestor_names.include? ancestor_name
+        end
+      end
+
+      def _attribute_default
+        default = actual_attribute_definition[:default]
+
+        case
+        when default.respond_to?(:call) then instance_exec(&default)
+        when default.duplicable? then default.dup
+        else default
         end
       end
     end

--- a/spec/functional/active_attr/matchers/have_attribute_matcher_spec.rb
+++ b/spec/functional/active_attr/matchers/have_attribute_matcher_spec.rb
@@ -167,6 +167,25 @@ module ActiveAttr
           end
         end
 
+        context "a class with the attribute and a different default (lazy evaluation)" do
+          before { model_class.attribute :first_name, :default => lambda { "Doe" } }
+
+          describe "#matches?" do
+            it { matcher.matches?(model_class).should == false }
+          end
+
+          describe "#failure_message" do
+            before { matcher.matches?(model_class) }
+
+            it do
+              matcher.failure_message.should match Regexp.new <<-MESSAGE.strip_heredoc.chomp, Regexp::MULTILINE
+                expected: attribute :first_name, :default => "John"
+                     got: attribute :first_name, :default => #<Proc.+?>
+              MESSAGE
+            end
+          end
+        end
+
         context "a class with the attribute and the right default" do
           before { model_class.attribute :first_name, :default => "John" }
 
@@ -182,6 +201,27 @@ module ActiveAttr
                 matcher.send(method).should == <<-MESSAGE.strip_heredoc.chomp
                   expected not: attribute :first_name, :default => "John"
                            got: attribute :first_name, :default => "John"
+                MESSAGE
+              end
+            end
+          end
+        end
+
+        context "a class with the attribute and the right default (lazy evaluation)" do
+          before { model_class.attribute :first_name, :default => lambda { "John" } }
+
+          describe "#matches?" do
+            it { matcher.matches?(model_class).should == true }
+          end
+
+          [:negative_failure_message, :failure_message_when_negated].each do |method|
+            describe "##{method}" do
+              before { matcher.matches?(model_class) }
+
+              it do
+                matcher.send(method).should match Regexp.new <<-MESSAGE.strip_heredoc.chomp, Regexp::MULTILINE
+                  expected not: attribute :first_name, :default => "John"
+                           got: attribute :first_name, :default => #<Proc.+?>
                 MESSAGE
               end
             end


### PR DESCRIPTION
When default value of actual attribute is set as Proc, `HaveAttributeMatcher#with_default_value_of` is unavailable on testing ( It cannot evaluate Proc ). So I make this PR.
- `actual_attribute_definition[:default]` is replaced with `_attribute_default`.
- `_attribute_default` can evaluate Proc ( Almost the same `AttributeDefaults#_attribute_default` )
- Add two examples in functional test.

This gem is so useful, thanks.
