### PR TITLE
Document available options for `.attribute`

### DIFF
--- a/lib/active_attr/attribute_definition.rb
+++ b/lib/active_attr/attribute_definition.rb
@@ -48,6 +48,10 @@ module ActiveAttr
     #
     # @param [Symbol, String, #to_sym] name attribute name
     # @param [Hash{Symbol => Object}] options attribute options
+    # @option options [Object] :default default value
+    # @option options [Object] :type type to coerce the value to
+    # @option options [Object] :typecaster object responding to `#call(value)`
+    #                          that returns the coerced value
     #
     # @return [ActiveAttr::AttributeDefinition]
     #

--- a/lib/active_attr/attributes.rb
+++ b/lib/active_attr/attributes.rb
@@ -165,6 +165,7 @@ module ActiveAttr
       #   attribute :name
       #
       # @param (see AttributeDefinition#initialize)
+      # @option (see AttributeDefinition#initialize)
       #
       # @raise [DangerousAttributeError] if the attribute name conflicts with
       #   existing methods
@@ -192,6 +193,7 @@ module ActiveAttr
       #   attribute! :timeout
       #
       # @param (see AttributeDefinition#initialize)
+      # @option (see AttributeDefinition#initialize)
       #
       # @return [AttributeDefinition] Attribute's definition
       #


### PR DESCRIPTION
Documents known options for `.attribute` and `.attribute!` .. There may be others that I'm not aware of?