### PR TITLE
Add license to gemspec

### DIFF
--- a/active_attr.gemspec
+++ b/active_attr.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Create plain old ruby models without reinventing the wheel.}
   gem.summary       = %q{What ActiveModel left out}
   gem.homepage      = "https://github.com/cgriego/active_attr"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
This PR adds license item to gemspec. This item is used as follows.

- Describing LICENSES on rubygems.org (https://rubygems.org/gems/active_attr)
- List of licenses displayed by `bundle licenses` command

This will increase the opportunity for users to learn about license.
