### PR TITLE
Relax dependency criteria to support Rails 5.2

### DIFF
--- a/active_attr.gemspec
+++ b/active_attr.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ActiveAttr::VERSION
 
-  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 5.2"
-  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 5.2"
+  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 5.3"
+  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 5.3"
 
   gem.add_development_dependency "bundler",      "~> 1.0"
   gem.add_development_dependency "factory_girl", ">= 2.2", "< 5.0"


### PR DESCRIPTION
Fixes #163 

I'll submit another PR (#165) after this to clean and enhance the travis build matrix