### PR TITLE
DateTimeTypecaster should returns nil if given string is not parsed b…

### DIFF
--- a/lib/active_attr/typecasting/date_time_typecaster.rb
+++ b/lib/active_attr/typecasting/date_time_typecaster.rb
@@ -25,6 +25,7 @@ module ActiveAttr
       # @since 0.5.0
       def call(value)
         value.to_datetime if value.respond_to? :to_datetime
+      rescue ArgumentError
       end
     end
   end

--- a/spec/unit/active_attr/typecasting/date_time_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/date_time_typecaster_spec.rb
@@ -16,6 +16,10 @@ module ActiveAttr
           typecaster.call(nil).should equal nil
         end
 
+        it "returns nil for invalid string" do
+          typecaster.call('not a datetime string').should equal nil
+        end
+
         it "casts a Date to a DateTime at the beginning of the day with no offset" do
           result = typecaster.call(Date.new(2012, 1, 1))
           result.should eql DateTime.new(2012, 1, 1)


### PR DESCRIPTION
Hello.
I suggest `DateTimeTypecaster#call` returns `nil` when `value. to_datetime` raises `ArgumentError`.

It is because that other typecaster's returns `nil` for bad input.
