### PR TITLE
Number regex in BooleanTypecaster incorrect for strings that start wi…

### DIFF
--- a/lib/active_attr/typecasting/boolean_typecaster.rb
+++ b/lib/active_attr/typecasting/boolean_typecaster.rb
@@ -34,7 +34,7 @@ module ActiveAttr
       def call(value)
         case value
         when *FALSE_VALUES then false
-        when Numeric, /^\-?[0-9]/ then !value.to_f.zero?
+        when Numeric, /^\-?\d+(\.\d+)?$/ then !value.to_f.zero?
         else value.present?
         end
       end

--- a/spec/unit/active_attr/typecasting/boolean_typecaster_spec.rb
+++ b/spec/unit/active_attr/typecasting/boolean_typecaster_spec.rb
@@ -33,6 +33,14 @@ module ActiveAttr
             typecaster.call("abc").should equal true
           end
 
+          it "casts a non-empty String starting with number 0 to true" do
+            typecaster.call("0c2").should equal true
+          end
+
+          it "casts a non-empty String starting with number > 0 to true" do
+            typecaster.call("1c2").should equal true
+          end
+
           {
             "t" => true,
             "f" => false,


### PR DESCRIPTION
…th number but contain other characters

The BooleanTypecaster only checks to see if a String starts with a number instead of checking to see if the entire string is a number (whether whole number or fractional). As a result, any String that starts with a number but isn't necessarily a number (e.g. a GUID) will be treated as a number. If that String happens to start with 0 then BooleanTypecaster will return false event though it should return true. This fixes that issue by ensuring the entire String is a number value and not just the first character.