### PR TITLE
Exclude Rails < 5 tests on truffleruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,4 +110,13 @@ matrix:
       gemfile: gemfiles/rails_4_2.gemfile
     - rvm: truffleruby-head
       gemfile: gemfiles/rails_3_0.gemfile
-    
+    - rvm: truffleruby-head
+      gemfile: gemfiles/rails_3_1.gemfile
+    - rvm: truffleruby-head
+      gemfile: gemfiles/rails_3_2.gemfile
+    - rvm: truffleruby-head
+      gemfile: gemfiles/rails_4_0.gemfile
+    - rvm: truffleruby-head
+      gemfile: gemfiles/rails_4_1.gemfile
+    - rvm: truffleruby-head
+      gemfile: gemfiles/rails_4_2.gemfile


### PR DESCRIPTION
`truffleruby-head` targets Ruby 2.7 now, and Rails < 5 is also excluded on CRuby 2.7.