### PR TITLE
Loosen runtime dependencies to allow Rails 6.1.x

### DIFF
--- a/active_attr.gemspec
+++ b/active_attr.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 1.9.2"
 
-  gem.add_runtime_dependency "actionpack",    ">= 3.0.2", "< 6.1"
-  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 6.1"
-  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 6.1"
+  gem.add_runtime_dependency "actionpack",    ">= 3.0.2", "< 6.2"
+  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 6.2"
+  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 6.2"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "factory_bot",  "< 5.0"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gemspec :development_group => :test, :path => ".."
+
+gem "activemodel",   "~> 6.0.0"
+gem "activesupport", "~> 6.0.0"
+gem "actionpack",    "~> 6.0.0"
+gem "activemodel-serializers-xml", :group => :test
+gem "protected_attributes_continued", :group => :test

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gemspec :development_group => :test, :path => ".."
+
+gem "activemodel",   "~> 6.1.0"
+gem "activesupport", "~> 6.1.0"
+gem "actionpack",    "~> 6.1.0"
+gem "activemodel-serializers-xml", :group => :test
+gem "protected_attributes_continued", :group => :test


### PR DESCRIPTION
https://weblog.rubyonrails.org/2020/12/9/Rails-6-1-0-release/