### PR TITLE
Loose upper dependency constraint for rails gems

### DIFF
--- a/active_attr.gemspec
+++ b/active_attr.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.1.0"
 
-  gem.add_runtime_dependency "actionpack",    ">= 3.0.2", "< 6.2"
-  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 6.2"
-  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 6.2"
+  gem.add_runtime_dependency "actionpack",    ">= 3.0.2", "< 7.0"
+  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 7.0"
+  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 7.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "factory_bot",  "< 5.0"


### PR DESCRIPTION
Recently Ruby on Rails developers [decided to skip 6.2 and go straight to 7.0](github.com/rails/rails/commit/1b455e2e9d6937d4107e19cb32e2f98aa08886b9).

As one of development dependencies for my [after_commit_everywhere](https://github.com/Envek/after_commit_everywhere) gem transitively depends on active_attr, my testing against HEAD versions of Rails is currently broken due to current dependency constraints with following error:

```
Bundler could not find compatible versions for gem "actionpack":
  In activerecord_master.gemfile:
    isolator (~> 0.7) was resolved to 0.7.0, which depends on
      sniffer (>= 0.3.1) was resolved to 0.4.0, which depends on
        active_attr (>= 0.10.2) was resolved to 0.15.1, which depends on
          actionpack (< 6.2, >= 3.0.2)

    rails was resolved to 7.0.0.alpha, which depends on
      actionpack (= 7.0.0.alpha)
```

Please loose upper bound of dependency constraint (in this PR) or remove it altogether. And release a new patch version!

Thank you in advance!