### PR TITLE
an inline proc/lambda typecaster executes in the instance context

### DIFF
--- a/lib/active_attr/typecasting.rb
+++ b/lib/active_attr/typecasting.rb
@@ -48,7 +48,11 @@ module ActiveAttr
     def typecast_attribute(typecaster, value)
       raise ArgumentError, "a typecaster must be given" unless typecaster.respond_to?(:call)
       return value if value.nil?
-      typecaster.call(value)
+      if typecaster.is_a? Proc
+        instance_exec value, &typecaster
+      else
+        typecaster.call(value)
+      end
     end
 
     # Resolve a Class to a typecaster

--- a/spec/functional/active_attr/typecasted_attributes_spec.rb
+++ b/spec/functional/active_attr/typecasted_attributes_spec.rb
@@ -19,12 +19,17 @@ module ActiveAttr
         attribute :float,       :type => Float
         attribute :integer,     :type => Integer
         attribute :string,      :type => String
+        attribute :self_care,   :type => Hash, :typecaster => lambda { |value| { value: value, instance_predefined_value: predefined } }
 
         attribute :unknown, :type => Class.new {
           def self.to_s
             "Unknown"
           end
         }
+
+        def predefined
+          :predefined_value
+        end
       end
     end
 
@@ -142,6 +147,11 @@ module ActiveAttr
       it "an attribute using an inline typecaster returns the result of the inline typecaster" do
         model.age = 2
         model.age.should == Age.new(2)
+      end
+
+      it "an inline proc/lambda typecaster executes in the instance context" do
+        model.self_care = :a_value
+        model.self_care.should == { value: :a_value, instance_predefined_value: :predefined_value }
       end
     end
   end


### PR DESCRIPTION
When using an inline typecaster proc/lambda you should be able to run it in the context of the object and using its methods.
In short we binds typecaster to the object.