### PR TITLE
Do not run specs agains TruffleRuby and Rails 5.x on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -183,6 +183,12 @@ jobs:
           gemfile: gemfiles/rails_4_1.gemfile
         - ruby: truffleruby-head
           gemfile: gemfiles/rails_4_2.gemfile
+        - ruby: truffleruby-head
+          gemfile: gemfiles/rails_5_0.gemfile
+        - ruby: truffleruby-head
+          gemfile: gemfiles/rails_5_1.gemfile
+        - ruby: truffleruby-head
+          gemfile: gemfiles/rails_5_2.gemfile
     env:
       Rails: ${{ matrix.rails }}
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}


### PR DESCRIPTION
The specs fail on CI against TruffleRuby head and Rails 5.0, 5.1 and 5.2.

TruffleRuby head is compatible with CRuby 3.1 now. And AFAIK Rails supports Ruby 3.0 and above only since Rails 6.0 (according to [this article](https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html) since 6.1). So the specs probably should be skipped for Rails 5.x and TruffleRuby head (similarlly to Ruby 3.0 that is skipped for Rails below 6.0).

Failed specs on CI (TruffleRuby head + Rails 5.0)

```
Failures:

  1) ActiveAttr::BasicModel it should behave like ActiveModel test model naming
     Failure/Error: send test

     ArgumentError:
       wrong number of arguments (given 2, expected 0..1)
     Shared Example Group: "ActiveModel" called from ./spec/unit/active_attr/basic_model_spec.rb:17
     # ./vendor/bundle/truffleruby/3.1.3.1/gems/i18n-1.12.0/lib/i18n.rb:210:in `translate'
     # ./vendor/bundle/truffleruby/3.1.3.1/gems/activemodel-5.0.7.2/lib/active_model/naming.rb:189:in `human'
     # ./vendor/bundle/truffleruby/3.1.3.1/gems/activemodel-5.0.7.2/lib/active_model/lint.rb:84:in `test_model_naming'
     # ./spec/support/active_model_lint.rb:24:in `block (3 levels) in <top (required)>'

Finished in 2.31 seconds (files took 2.25 seconds to load)
361 examples, 1 failure

Failed examples:

rspec './spec/unit/active_attr/basic_model_spec.rb[1:1:2]' # ActiveAttr::BasicModel it should behave like ActiveModel test model naming
```

https://github.com/cgriego/active_attr/actions/runs/3831052664/jobs/6519707760