### PR TITLE
rails 7.1-alpha

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source "https://rubygems.org"
 
 gemspec :development_group => :test
 
-gem "activemodel",   "~> 7.0.0"
-gem "activesupport", "~> 7.0.0"
-gem "actionpack",    "~> 7.0.0"
+gem "activemodel", :git => "https://github.com/rails/rails.git"
+gem "activesupport", :git => "https://github.com/rails/rails.git"
+gem "actionpack", :git => "https://github.com/rails/rails.git"
 gem "activemodel-serializers-xml", :group => :test
 gem "rexml", :group => :test
 gem "protected_attributes_continued", :group => :test


### PR DESCRIPTION
Getting this error with Rails 7.1-alpha

```
[138, 147] in /home/mathieu/.asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/rspec-support-3.12.0/lib/rspec/support.rb
   138:       # These exceptions are dangerous to rescue as rescuing them
   139:       # would interfere with things we should not interfere with.
   140:       AVOID_RESCUING = [NoMemoryError, SignalException, Interrupt, SystemExit]
   141: 
   142:       def self.===(exception)
=> 143:         AVOID_RESCUING.none? { |ar| ar === exception }
   144:       end
   145:     end
   146: 
   147:     # The Differ is only needed when a spec fails with a diffable failure.
(byebug) exception
#<NameError: undefined local variable or method `attribute_method_matchers' for PayrollModules::PayItem:Class>
(byebug) puts exception.backtrace
/home/mathieu/.asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/gems/active_attr-0.15.4/lib/active_attr/attributes.rb:69:in `block in <module:Attributes>'
/home/mathieu/.asdf/installs/ruby/3.0.5/lib/ruby/gems/3.0.0/bundler/gems/rails-5a16eadbc31b/activesupport/lib/active_support/concern.rb:136:in `class_eval'
```