### PR TITLE
Add support for Rails 7.2

### DIFF
--- a/active_attr.gemspec
+++ b/active_attr.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.1.0"
 
-  gem.add_runtime_dependency "actionpack",    ">= 3.0.2", "< 7.2"
-  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 7.2"
-  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 7.2"
+  gem.add_runtime_dependency "actionpack",    ">= 3.0.2", "< 8.0"
+  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 8.0"
+  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 8.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "factory_bot",  "< 5.0"


### PR DESCRIPTION
This should add Rails 7.2 support
- tests pass
- Works on my existing application with Rails 7.2/Ruby 3.3.4