### PR TITLE
Rails 8 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,6 +41,7 @@ jobs:
         - gemfiles/rails_6_1.gemfile
         - gemfiles/rails_7_0.gemfile
         - gemfiles/rails_7_1.gemfile
+        - gemfiles/rails_7_2.gemfile
         - Gemfile
         - gemfiles/rails_head.gemfile
         exclude:
@@ -59,6 +60,8 @@ jobs:
         - ruby: "2.1"
           gemfile: gemfiles/rails_7_1.gemfile
         - ruby: "2.1"
+          gemfile: gemfiles/rails_7_2.gemfile
+        - ruby: "2.1"
           gemfile: Gemfile
         - ruby: "2.1"
           gemfile: gemfiles/rails_head.gemfile
@@ -71,6 +74,8 @@ jobs:
         - ruby: "2.2"
           gemfile: gemfiles/rails_7_1.gemfile
         - ruby: "2.2"
+          gemfile: gemfiles/rails_7_2.gemfile
+        - ruby: "2.2"
           gemfile: Gemfile
         - ruby: "2.2"
           gemfile: gemfiles/rails_head.gemfile
@@ -83,6 +88,8 @@ jobs:
         - ruby: "2.3"
           gemfile: gemfiles/rails_7_1.gemfile
         - ruby: "2.3"
+          gemfile: gemfiles/rails_7_2.gemfile
+        - ruby: "2.3"
           gemfile: Gemfile
         - ruby: "2.3"
           gemfile: gemfiles/rails_head.gemfile
@@ -95,6 +102,8 @@ jobs:
         - ruby: "2.4"
           gemfile: gemfiles/rails_7_1.gemfile
         - ruby: "2.4"
+          gemfile: gemfiles/rails_7_2.gemfile
+        - ruby: "2.4"
           gemfile: Gemfile
         - ruby: "2.4"
           gemfile: gemfiles/rails_head.gemfile
@@ -107,6 +116,8 @@ jobs:
         - ruby: "2.5"
           gemfile: gemfiles/rails_7_1.gemfile
         - ruby: "2.5"
+          gemfile: gemfiles/rails_7_2.gemfile
+        - ruby: "2.5"
           gemfile: Gemfile
         - ruby: "2.5"
           gemfile: gemfiles/rails_head.gemfile
@@ -118,6 +129,8 @@ jobs:
           gemfile: gemfiles/rails_7_0.gemfile
         - ruby: "2.6"
           gemfile: gemfiles/rails_7_1.gemfile
+        - ruby: "2.6"
+          gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.6"
           gemfile: Gemfile
         - ruby: "2.6"
@@ -134,6 +147,8 @@ jobs:
           gemfile: gemfiles/rails_4_1.gemfile
         - ruby: "2.7"
           gemfile: gemfiles/rails_4_2.gemfile
+        - ruby: "2.7"
+          gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.7"
           gemfile: Gemfile
         - ruby: "2.7"
@@ -156,6 +171,8 @@ jobs:
           gemfile: gemfiles/rails_5_1.gemfile
         - ruby: "3.0"
           gemfile: gemfiles/rails_5_2.gemfile
+        - ruby: "3.0"
+          gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "3.0"
           gemfile: Gemfile
         - ruby: "3.0"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,7 @@ jobs:
         - gemfiles/rails_7_0.gemfile
         - gemfiles/rails_7_1.gemfile
         - gemfiles/rails_7_2.gemfile
+        - gemfiles/rails_8_0.gemfile
         - Gemfile
         - gemfiles/rails_head.gemfile
         exclude:
@@ -62,6 +63,8 @@ jobs:
         - ruby: "2.1"
           gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.1"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "2.1"
           gemfile: Gemfile
         - ruby: "2.1"
           gemfile: gemfiles/rails_head.gemfile
@@ -76,6 +79,8 @@ jobs:
         - ruby: "2.2"
           gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.2"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "2.2"
           gemfile: Gemfile
         - ruby: "2.2"
           gemfile: gemfiles/rails_head.gemfile
@@ -90,6 +95,8 @@ jobs:
         - ruby: "2.3"
           gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.3"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "2.3"
           gemfile: Gemfile
         - ruby: "2.3"
           gemfile: gemfiles/rails_head.gemfile
@@ -104,6 +111,8 @@ jobs:
         - ruby: "2.4"
           gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.4"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "2.4"
           gemfile: Gemfile
         - ruby: "2.4"
           gemfile: gemfiles/rails_head.gemfile
@@ -118,6 +127,8 @@ jobs:
         - ruby: "2.5"
           gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.5"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "2.5"
           gemfile: Gemfile
         - ruby: "2.5"
           gemfile: gemfiles/rails_head.gemfile
@@ -132,6 +143,8 @@ jobs:
         - ruby: "2.6"
           gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.6"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "2.6"
           gemfile: Gemfile
         - ruby: "2.6"
           gemfile: gemfiles/rails_head.gemfile
@@ -150,6 +163,8 @@ jobs:
         - ruby: "2.7"
           gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "2.7"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "2.7"
           gemfile: Gemfile
         - ruby: "2.7"
           gemfile: gemfiles/rails_head.gemfile
@@ -174,6 +189,8 @@ jobs:
         - ruby: "3.0"
           gemfile: gemfiles/rails_7_2.gemfile
         - ruby: "3.0"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "3.0"
           gemfile: Gemfile
         - ruby: "3.0"
           gemfile: gemfiles/rails_head.gemfile
@@ -195,6 +212,10 @@ jobs:
           gemfile: gemfiles/rails_5_1.gemfile
         - ruby: "3.1"
           gemfile: gemfiles/rails_5_2.gemfile
+        - ruby: "3.1"
+          gemfile: gemfiles/rails_8_0.gemfile
+        - ruby: "3.1"
+          gemfile: Gemfile
         - ruby: "3.1"
           gemfile: gemfiles/rails_head.gemfile
         - ruby: "3.2"

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source "https://rubygems.org"
 
 gemspec :development_group => :test
 
-gem "activemodel",   "~> 7.2.0"
-gem "activesupport", "~> 7.2.0"
-gem "actionpack",    "~> 7.2.0"
 gem "activemodel-serializers-xml", :group => :test
 gem "rexml", :group => :test
 gem "protected_attributes_continued", :group => :test

--- a/active_attr.gemspec
+++ b/active_attr.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 2.1.0"
 
-  gem.add_runtime_dependency "actionpack",    ">= 3.0.2", "< 8.0"
-  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 8.0"
-  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 8.0"
+  gem.add_runtime_dependency "actionpack",    ">= 3.0.2", "< 9.0"
+  gem.add_runtime_dependency "activemodel",   ">= 3.0.2", "< 9.0"
+  gem.add_runtime_dependency "activesupport", ">= 3.0.2", "< 9.0"
 
   gem.add_development_dependency "bundler"
   gem.add_development_dependency "factory_bot",  "< 7.0"

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gemspec :development_group => :test, :path => ".."
+
+gem "activemodel",   "~> 7.2.0"
+gem "activesupport", "~> 7.2.0"
+gem "actionpack",    "~> 7.2.0"
+gem "activemodel-serializers-xml", :group => :test
+gem "rexml", :group => :test
+gem "protected_attributes_continued", :group => :test

--- a/gemfiles/rails_8_0.gemfile
+++ b/gemfiles/rails_8_0.gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+gemspec :development_group => :test, :path => ".."
+
+gem "activemodel",   "~> 8.0.0"
+gem "activesupport", "~> 8.0.0"
+gem "actionpack",    "~> 8.0.0"
+gem "activemodel-serializers-xml", :group => :test
+gem "rexml", :group => :test
+gem "protected_attributes_continued", :group => :test


### PR DESCRIPTION
- Add Rails 7.2 to the build matrix
- Add support for Rails 8
- Remove dupes from the Gemfile (They're already specified in the gemspec)

Fixes #204