### PR TITLE
Fix frozen model can still be modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# ActiveAttr 0.18.0 (Unreleased)
+
+* Frozen models now correctly raise a frozen object error when an attempt is made to modify them
+
 # ActiveAttr 0.17.2 (November 21, 2025)
 
 * ActiveAttr now supports Ruby 3.4

--- a/lib/active_attr/attributes.rb
+++ b/lib/active_attr/attributes.rb
@@ -171,11 +171,6 @@ module ActiveAttr
     end
     alias_method :[]=, :write_attribute
 
-    # Freeze the model and its attributes, preventing further modification.
-    #
-    # @return [self]
-    #
-    # @since 0.17.3
     def freeze
       @attributes ||= {}
       @attributes.freeze

--- a/lib/active_attr/attributes.rb
+++ b/lib/active_attr/attributes.rb
@@ -171,7 +171,12 @@ module ActiveAttr
     end
     alias_method :[]=, :write_attribute
 
+    # Freeze the model and its attributes, preventing further modification.
+    #
+    # @return [self]
+    #
     # @private
+    # @since 0.18.0
     def freeze
       @attributes ||= {}
       @attributes.freeze

--- a/lib/active_attr/attributes.rb
+++ b/lib/active_attr/attributes.rb
@@ -171,6 +171,7 @@ module ActiveAttr
     end
     alias_method :[]=, :write_attribute
 
+    # @private
     def freeze
       @attributes ||= {}
       @attributes.freeze

--- a/lib/active_attr/attributes.rb
+++ b/lib/active_attr/attributes.rb
@@ -171,6 +171,17 @@ module ActiveAttr
     end
     alias_method :[]=, :write_attribute
 
+    # Freeze the model and its attributes, preventing further modification.
+    #
+    # @return [self]
+    #
+    # @since 0.17.3
+    def freeze
+      @attributes ||= {}
+      @attributes.freeze
+      super
+    end
+
     private
 
     # Read an attribute from the attributes hash

--- a/lib/active_attr/version.rb
+++ b/lib/active_attr/version.rb
@@ -1,5 +1,5 @@
 module ActiveAttr
   # Complete version string
   # @since 0.1.0
-  VERSION = "0.17.2"
+  VERSION = "0.18.0"
 end

--- a/spec/functional/active_attr/mass_assignment_spec.rb
+++ b/spec/functional/active_attr/mass_assignment_spec.rb
@@ -82,21 +82,12 @@ module ActiveAttr
 
       before { model.freeze }
 
-      it "raises when using a generated attribute setter" do
-        expect { model.first_name = "Ben" }.to raise_error(frozen_error_class)
-      end
-
       it "raises when using assign_attributes" do
         expect { model.assign_attributes(:first_name => "Ben") }.to raise_error(frozen_error_class)
       end
 
       it "raises when using attributes=" do
         expect { model.attributes = { :first_name => "Ben" } }.to raise_error(frozen_error_class)
-      end
-
-      it "does not raise when reading attributes" do
-        expect { model.first_name }.not_to raise_error
-        expect { model.attributes }.not_to raise_error
       end
     end
 

--- a/spec/functional/active_attr/mass_assignment_spec.rb
+++ b/spec/functional/active_attr/mass_assignment_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "active_attr/attributes"
 require "active_attr/mass_assignment"
 require "active_model"
 require "active_model/mass_assignment_security"
@@ -64,6 +65,38 @@ module ActiveAttr
         describe "#assign_attributes", :assign_attributes, :secure_mass_assignment_method, :secure_mass_assignment_method_with_options
         describe "#attributes=", :attributes=, :secure_mass_assignment_method
         describe "#initialize", :initialize, :secure_mass_assignment_method, :secure_mass_assignment_method_with_options
+      end
+    end
+
+    context "integrating with Attributes (frozen model)" do
+      let :model_class do
+        Class.new do
+          include Attributes
+          include MassAssignment
+          attribute :first_name
+          attribute :last_name
+        end
+      end
+
+      subject(:model) { model_class.new }
+
+      before { model.freeze }
+
+      it "raises when using a generated attribute setter" do
+        expect { model.first_name = "Ben" }.to raise_error(frozen_error_class)
+      end
+
+      it "raises when using assign_attributes" do
+        expect { model.assign_attributes(:first_name => "Ben") }.to raise_error(frozen_error_class)
+      end
+
+      it "raises when using attributes=" do
+        expect { model.attributes = { :first_name => "Ben" } }.to raise_error(frozen_error_class)
+      end
+
+      it "does not raise when reading attributes" do
+        expect { model.first_name }.not_to raise_error
+        expect { model.attributes }.not_to raise_error
       end
     end
 

--- a/spec/support/frozen_error.rb
+++ b/spec/support/frozen_error.rb
@@ -1,0 +1,5 @@
+# Returns the appropriate frozen error class for the current Ruby version.
+# FrozenError was introduced in Ruby 2.5; older Rubies raise RuntimeError.
+def frozen_error_class
+  defined?(FrozenError) ? FrozenError : RuntimeError
+end

--- a/spec/support/frozen_error.rb
+++ b/spec/support/frozen_error.rb
@@ -1,5 +1,11 @@
-# Returns the appropriate frozen error class for the current Ruby version.
-# FrozenError was introduced in Ruby 2.5; older Rubies raise RuntimeError.
-def frozen_error_class
-  defined?(FrozenError) ? FrozenError : RuntimeError
+module FrozenErrorHelper
+  # Returns the appropriate frozen error class for the current Ruby version.
+  # FrozenError was introduced in Ruby 2.5; older Rubies raise RuntimeError.
+  def frozen_error_class
+    defined?(FrozenError) ? FrozenError : RuntimeError
+  end
+end
+
+RSpec.configure do |config|
+  config.include FrozenErrorHelper
 end

--- a/spec/unit/active_attr/attribute_defaults_spec.rb
+++ b/spec/unit/active_attr/attribute_defaults_spec.rb
@@ -47,5 +47,28 @@ module ActiveAttr
         should be_initialized
       end
     end
+
+    describe "#freeze" do
+      context "when frozen before defaults are applied" do
+        subject(:frozen_model) do
+          model_class.new.tap do |m|
+            m.instance_variable_set(:@attributes, {})
+            m.freeze
+          end
+        end
+
+        it "raises when apply_defaults is called with missing keys" do
+          expect { frozen_model.apply_defaults }.to raise_error(frozen_error_class)
+        end
+      end
+
+      context "when frozen after initialization (defaults already applied)" do
+        before { model.freeze }
+
+        it "does not raise when apply_defaults is called" do
+          expect { model.apply_defaults }.not_to raise_error
+        end
+      end
+    end
   end
 end

--- a/spec/unit/active_attr/attributes_spec.rb
+++ b/spec/unit/active_attr/attributes_spec.rb
@@ -372,6 +372,10 @@ module ActiveAttr
           expect { model[:first_name] = "Ben" }.to raise_error(frozen_error_class)
         end
 
+        it "raises when using a generated attribute setter" do
+          expect { model.first_name = "Ben" }.to raise_error(frozen_error_class)
+        end
+
         it "does not raise when reading with read_attribute" do
           expect { model.read_attribute(:first_name) }.not_to raise_error
         end

--- a/spec/unit/active_attr/attributes_spec.rb
+++ b/spec/unit/active_attr/attributes_spec.rb
@@ -352,6 +352,44 @@ module ActiveAttr
       end
     end
 
+    describe "#freeze" do
+      it "returns self" do
+        model.freeze.should equal model
+      end
+
+      it "makes the model frozen" do
+        model.freeze.should be_frozen
+      end
+
+      context "when frozen" do
+        before { model.freeze }
+
+        it "raises when writing with write_attribute" do
+          expect { model.write_attribute(:first_name, "Ben") }.to raise_error(frozen_error_class)
+        end
+
+        it "raises when writing with []=" do
+          expect { model[:first_name] = "Ben" }.to raise_error(frozen_error_class)
+        end
+
+        it "does not raise when reading with read_attribute" do
+          expect { model.read_attribute(:first_name) }.not_to raise_error
+        end
+
+        it "does not raise when reading with []" do
+          expect { model[:first_name] }.not_to raise_error
+        end
+
+        it "does not raise when calling #attributes" do
+          expect { model.attributes }.not_to raise_error
+        end
+
+        it "does not raise when calling #inspect" do
+          expect { model.inspect }.not_to raise_error
+        end
+      end
+    end
+
     [:[]=, :write_attribute].each do |method|
       describe "##{method}" do
         it "raises ArgumentError with one argument" do

--- a/spec/unit/active_attr/typecasted_attributes_spec.rb
+++ b/spec/unit/active_attr/typecasted_attributes_spec.rb
@@ -75,6 +75,14 @@ module ActiveAttr
         model.amount = value
         model.attribute_before_type_cast('amount').should equal value
       end
+
+      context "when frozen" do
+        before { model.freeze }
+
+        it "does not raise" do
+          expect { model.attribute_before_type_cast(:amount) }.not_to raise_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Override #freeze in Attributes to initialize and freeze @attributes,
ensuring that any attempt to write to a frozen model naturally raises
FrozenError (RuntimeError on Ruby < 2.5) via the frozen Hash.

Add frozen_error_class test helper in spec/support for Ruby version
compatibility. Write tests covering write_attribute, []=, reads,
inspect, apply_defaults (unit), and assign_attributes/attributes=
across the MassAssignment + Attributes boundary (functional).

https://claude.ai/code/session_01MPZp1QECyJ3vnRxgStE1p8